### PR TITLE
Add library search, sorting, document rename, and UI polish

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,13 +18,57 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Runner images don't always ship the same pre-created simulators
+      # (hardcoding a device name broke when an image update dropped it),
+      # so pick any available iPhone — and create one if none exist.
+      - name: Select iOS simulator
+        id: simulator
+        run: |
+          set -euo pipefail
+          xcrun simctl list devices available
+          UDID=$(python3 - <<'EOF'
+          import json
+          import subprocess
+
+          def simctl(*args):
+              return json.loads(subprocess.check_output(["xcrun", "simctl", "list", *args, "--json"]))
+
+          devices = simctl("devices", "available")["devices"]
+          iphones = [
+              device
+              for runtime_devices in devices.values()
+              for device in runtime_devices
+              if device.get("isAvailable") and device["name"].startswith("iPhone")
+          ]
+          if iphones:
+              print(iphones[0]["udid"])
+          else:
+              device_types = [
+                  t["identifier"]
+                  for t in simctl("devicetypes")["devicetypes"]
+                  if t["identifier"].rsplit(".", 1)[-1].startswith("iPhone")
+              ]
+              runtimes = [
+                  r["identifier"]
+                  for r in simctl("runtimes")["runtimes"]
+                  if r.get("isAvailable") and ".iOS-" in r["identifier"]
+              ]
+              udid = subprocess.check_output(
+                  ["xcrun", "simctl", "create", "CI iPhone", device_types[-1], runtimes[-1]]
+              ).decode().strip()
+              print(udid)
+          EOF
+          )
+          echo "Selected simulator: $UDID"
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
+
       - name: Run tests
         run: |
           set -o pipefail
           xcodebuild test \
             -project Strobe.xcodeproj \
             -scheme Strobe \
-            -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+            -destination "platform=iOS Simulator,id=${{ steps.simulator.outputs.udid }}" \
             -resultBundlePath TestResults.xcresult \
             -skipPackagePluginValidation \
             -skip-testing:StrobeUITests \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,30 +33,41 @@ jobs:
           def simctl(*args):
               return json.loads(subprocess.check_output(["xcrun", "simctl", "list", *args, "--json"]))
 
+          def ios_version(identifier):
+              # com.apple.CoreSimulator.SimRuntime.iOS-26-4 -> (26, 4)
+              suffix = identifier.rsplit(".iOS-", 1)[-1]
+              return tuple(int(part) for part in suffix.split("-") if part.isdigit())
+
+          # Prefer an iPhone on the NEWEST installed iOS runtime — the devices
+          # dict is keyed by runtime identifier with no ordering guarantee.
           devices = simctl("devices", "available")["devices"]
-          iphones = [
-              device
-              for runtime_devices in devices.values()
-              for device in runtime_devices
-              if device.get("isAvailable") and device["name"].startswith("iPhone")
-          ]
-          if iphones:
-              print(iphones[0]["udid"])
-          else:
+          udid = None
+          for key in sorted((k for k in devices if ".iOS-" in k), key=ios_version, reverse=True):
+              iphones = [
+                  d for d in devices[key]
+                  if d.get("isAvailable") and d["name"].startswith("iPhone")
+              ]
+              if iphones:
+                  udid = iphones[0]["udid"]
+                  break
+
+          if udid is None:
               device_types = [
                   t["identifier"]
                   for t in simctl("devicetypes")["devicetypes"]
                   if t["identifier"].rsplit(".", 1)[-1].startswith("iPhone")
               ]
-              runtimes = [
-                  r["identifier"]
-                  for r in simctl("runtimes")["runtimes"]
-                  if r.get("isAvailable") and ".iOS-" in r["identifier"]
-              ]
+              runtimes = sorted(
+                  (r["identifier"]
+                   for r in simctl("runtimes")["runtimes"]
+                   if r.get("isAvailable") and ".iOS-" in r["identifier"]),
+                  key=ios_version,
+              )
               udid = subprocess.check_output(
                   ["xcrun", "simctl", "create", "CI iPhone", device_types[-1], runtimes[-1]]
               ).decode().strip()
-              print(udid)
+
+          print(udid)
           EOF
           )
           echo "Selected simulator: $UDID"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Do NOT run `xcodebuild` commands.** The user builds and tests separately in Xcode.
 
-The project targets iOS 17.0+ / macOS 14.0+ and uses the `Strobe` scheme. CI runs on GitHub Actions with `macos-26`, testing both `iPhone 17 Pro` simulator and native macOS.
+The project targets iOS 17.0+ / macOS 14.0+ and uses the `Strobe` scheme. CI runs on GitHub Actions with `macos-26`, testing both an iOS simulator (any available iPhone, selected dynamically) and native macOS.
 
 ### Testing
 Tests use the **Swift Testing** framework (not XCTest):

--- a/Strobe/App/StrobeApp.swift
+++ b/Strobe/App/StrobeApp.swift
@@ -34,9 +34,11 @@ struct StrobeApp: App {
 
         #if os(macOS)
         // Standard macOS Settings window, reachable via Cmd+, from anywhere.
+        // Min width must exceed the Replay Tutorial sheet's 600pt so the
+        // sheet never overhangs its parent window.
         Settings {
             SettingsView()
-                .frame(minWidth: 560, minHeight: 620)
+                .frame(minWidth: 640, minHeight: 620)
                 .preferredColorScheme(.dark)
         }
         #endif

--- a/Strobe/App/StrobeApp.swift
+++ b/Strobe/App/StrobeApp.swift
@@ -31,6 +31,15 @@ struct StrobeApp: App {
         .defaultSize(width: 900, height: 700)
         .windowStyle(.hiddenTitleBar)
         #endif
+
+        #if os(macOS)
+        // Standard macOS Settings window, reachable via Cmd+, from anywhere.
+        Settings {
+            SettingsView()
+                .frame(minWidth: 560, minHeight: 620)
+                .preferredColorScheme(.dark)
+        }
+        #endif
     }
 
     private struct BootstrapResult {

--- a/Strobe/Engine/WordComplexityAnalyzer.swift
+++ b/Strobe/Engine/WordComplexityAnalyzer.swift
@@ -87,14 +87,17 @@ enum WordComplexityAnalyzer {
         var lexicalTags = [NLTag?](repeating: nil, count: words.count)
         var entityTags = [NLTag?](repeating: nil, count: words.count)
 
-        // Character offset where each word starts in `text` (words are joined
-        // by single spaces, so offsets are exact by construction).
+        // Unicode-scalar offset where each word starts in `text`. Scalar counts
+        // are used instead of Character counts because joining can merge
+        // graphemes across the separator (a word starting with a combining
+        // mark merges with the preceding space into one Character), which
+        // would desync a Character-based table for every following word.
         var wordStarts: [Int] = []
         wordStarts.reserveCapacity(words.count)
         var offset = 0
         for word in words {
             wordStarts.append(offset)
-            offset += word.count + 1
+            offset += word.unicodeScalars.count + 1
         }
 
         // Tokens arrive in document order, so a forward cursor over both the
@@ -109,7 +112,7 @@ enum WordComplexityAnalyzer {
             scheme: .lexicalClass,
             options: [.omitWhitespace, .omitPunctuation]
         ) { tag, range in
-            cursorOffset += text.distance(from: cursorIndex, to: range.lowerBound)
+            cursorOffset += text.unicodeScalars.distance(from: cursorIndex, to: range.lowerBound)
             cursorIndex = range.lowerBound
             while wordIndex + 1 < words.count && cursorOffset >= wordStarts[wordIndex + 1] {
                 wordIndex += 1

--- a/Strobe/Import/EPUBTextExtractor.swift
+++ b/Strobe/Import/EPUBTextExtractor.swift
@@ -504,7 +504,14 @@ private final class SimpleXMLParser: NSObject, XMLParserDelegate, @unchecked Sen
 
     nonisolated func parser(_ parser: XMLParser, foundCharacters string: String) {
         for index in openElementIndices {
-            elements[index].text = (elements[index].text ?? "") + string
+            // In-place append: `(text ?? "") + string` copies each long-lived
+            // ancestor's entire accumulated text on every callback, which is
+            // quadratic for large nav/TOC documents.
+            if elements[index].text == nil {
+                elements[index].text = string
+            } else {
+                elements[index].text?.append(string)
+            }
         }
     }
 

--- a/Strobe/Import/ZIPExtractor.swift
+++ b/Strobe/Import/ZIPExtractor.swift
@@ -48,9 +48,10 @@ enum ZIPExtractor {
     ///   - source: The file URL of the ZIP archive.
     ///   - destination: The directory to extract files into (created if needed).
     ///   - maxTotalBytes: Cumulative extraction budget across all entries.
+    ///     Entries that would exceed the remaining budget are skipped (not
+    ///     written), bounding disk usage without failing the whole archive.
     /// - Throws: File system errors if directories cannot be created or files
-    ///   written, or ``DocumentImportError/epubExtractionFailed`` when the
-    ///   archive expands past `maxTotalBytes`.
+    ///   written.
     nonisolated static func extract(
         zipAt source: URL,
         to destination: URL,
@@ -287,9 +288,13 @@ enum ZIPExtractor {
             return
         }
 
+        // Skip (rather than abort on) entries that exceed the remaining budget:
+        // the cap exists to bound disk usage, and legitimate media-heavy EPUBs
+        // can exceed it with images/audio the text pipeline never reads. Small
+        // text entries later in the archive still extract from what remains.
         guard budget.charge(fileData.count) else {
-            logger.warning("Archive exceeds total extraction budget at entry: \(name, privacy: .public) — possible ZIP bomb")
-            throw DocumentImportError.epubExtractionFailed
+            logger.warning("Skipping entry over total extraction budget: \(name, privacy: .public) — possible ZIP bomb or oversized media")
+            return
         }
 
         try fileData.write(to: fileURL)

--- a/Strobe/Views/ChapterListView.swift
+++ b/Strobe/Views/ChapterListView.swift
@@ -9,11 +9,6 @@ struct ChapterListView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Bindable var document: Document
-    @AppStorage(ReaderFont.storageKey) private var readerFontSelection = ReaderFont.defaultValue.rawValue
-
-    private var readerFont: ReaderFont {
-        ReaderFont.resolve(readerFontSelection)
-    }
 
     private var contentMaxWidth: CGFloat {
         horizontalSizeClass == .regular ? 720 : .infinity
@@ -45,7 +40,7 @@ struct ChapterListView: View {
                         // Chapters
                         LazyVStack(spacing: 12) {
                             ForEach(Array(document.chapters.enumerated()), id: \.element.id) { index, chapter in
-                                NavigationLink(destination: ReaderView(document: document, startingWordIndex: chapter.wordIndex)) {
+                                NavigationLink(destination: ReaderView(document: document, startingWordIndex: startingWordIndex(forChapterAt: index))) {
                                     chapterRow(chapter: chapter, index: index)
                                 }
                                 .buttonStyle(StrobeCardButtonStyle())
@@ -67,7 +62,6 @@ struct ChapterListView: View {
 
     private var header: some View {
         HStack(spacing: 16) {
-            #if os(iOS)
             Button {
                 dismiss()
             } label: {
@@ -79,7 +73,7 @@ struct ChapterListView: View {
                     .clipShape(Circle())
             }
             .buttonStyle(.plain)
-            #endif
+            .accessibilityLabel("Back")
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(document.title)
@@ -173,6 +167,19 @@ struct ChapterListView: View {
 
     private enum ChapterStatus {
         case notStarted, inProgress, completed
+    }
+
+    /// Where the reader should start when a chapter row is tapped.
+    ///
+    /// An in-progress chapter resumes at the user's current position instead of
+    /// restarting at the chapter's first word — otherwise tapping the chapter
+    /// you're partway through (and then leaving the reader) would overwrite
+    /// your saved position with the chapter start.
+    private func startingWordIndex(forChapterAt index: Int) -> Int {
+        if chapterStatus(at: index) == .inProgress {
+            return document.currentWordIndex
+        }
+        return document.chapters[index].wordIndex
     }
 
     private func chapterWordCount(at index: Int) -> Int {

--- a/Strobe/Views/ContentView.swift
+++ b/Strobe/Views/ContentView.swift
@@ -11,9 +11,9 @@ struct ContentView: View {
     @Query(sort: \Document.dateAdded, order: .reverse) private var documents: [Document]
 
     @AppStorage(ReaderSettings.Keys.defaultWPM) private var defaultWPM: Int = ReaderSettings.Defaults.defaultWPM
-    @AppStorage(ReaderFont.storageKey) private var readerFontSelection = ReaderFont.defaultValue.rawValue
     @AppStorage(TextCleaningLevel.storageKey) private var textCleaningLevel = TextCleaningLevel.defaultValue.rawValue
     @AppStorage("hasSeenTutorial") private var hasSeenTutorial = false
+    @AppStorage(LibrarySortOrder.storageKey) private var librarySortOrderRaw = LibrarySortOrder.defaultValue.rawValue
 
     @State private var isImporting = false
     @State private var isProcessingImport = false
@@ -23,6 +23,10 @@ struct ContentView: View {
     @State private var showTutorial = false
     @State private var showTextInput = false
     @State private var documentPendingDeletion: Document?
+    @State private var documentPendingRename: Document?
+    @State private var renameText = ""
+    @State private var searchText = ""
+    @State private var isDropTargeted = false
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
@@ -32,8 +36,25 @@ struct ContentView: View {
         return [GridItem(.adaptive(minimum: minWidth), spacing: 16)]
     }
 
-    private var readerFont: ReaderFont {
-        ReaderFont.resolve(readerFontSelection)
+    private var sortOrder: LibrarySortOrder {
+        LibrarySortOrder(rawValue: librarySortOrderRaw) ?? LibrarySortOrder.defaultValue
+    }
+
+    /// Documents re-sorted by the user's chosen order and filtered by the
+    /// search query. The base `@Query` is already newest-first by date added.
+    private var displayedDocuments: [Document] {
+        var result = documents
+        switch sortOrder {
+        case .dateAdded:
+            break
+        case .lastRead:
+            result.sort { ($0.lastReadDate ?? .distantPast) > ($1.lastReadDate ?? .distantPast) }
+        case .title:
+            result.sort { $0.title.localizedStandardCompare($1.title) == .orderedAscending }
+        }
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return result }
+        return result.filter { $0.title.localizedCaseInsensitiveContains(query) }
     }
 
     var body: some View {
@@ -45,13 +66,20 @@ struct ContentView: View {
 
                 VStack(spacing: 0) {
                     customHeader
-                    
+
                     if documents.isEmpty {
                         Spacer()
                         emptyState
                         Spacer()
                     } else {
-                        documentGrid
+                        searchBar
+                        if displayedDocuments.isEmpty {
+                            Spacer()
+                            noSearchResults
+                            Spacer()
+                        } else {
+                            documentGrid
+                        }
                     }
                 }
 
@@ -65,19 +93,34 @@ struct ContentView: View {
                             .padding(.bottom, 24)
                     }
                 }
+
+                if isDropTargeted {
+                    RoundedRectangle(cornerRadius: 24)
+                        .stroke(StrobeTheme.accent, lineWidth: 2)
+                        .background(
+                            RoundedRectangle(cornerRadius: 24)
+                                .fill(StrobeTheme.accent.opacity(0.06))
+                        )
+                        .padding(8)
+                        .allowsHitTesting(false)
+                        .transition(.opacity)
+                }
             }
+            .animation(.easeInOut(duration: 0.15), value: isDropTargeted)
             #if os(iOS)
             .toolbar(.hidden, for: .navigationBar)
             #endif
+            #if os(iOS)
+            // On macOS, settings open in the standard Settings window (Cmd+,)
+            // via SettingsLink instead of a sheet.
             .sheet(isPresented: $showSettings) {
                 SettingsView()
-                    #if os(iOS)
                     // On iPad (regular width) the medium detent is too small;
                     // offer large only so settings fills the sheet properly.
                     .presentationDetents(horizontalSizeClass == .regular ? [.large] : [.medium, .large])
                     .presentationCornerRadius(24)
-                    #endif
             }
+            #endif
             #if os(iOS)
             .fullScreenCover(isPresented: $showTutorial) {
                 TutorialView()
@@ -113,13 +156,34 @@ struct ContentView: View {
                     importOverlay
                 }
             }
-            .alert("Error", isPresented: .init(
+            .alert("Couldn't Import File", isPresented: .init(
                 get: { importError != nil },
                 set: { if !$0 { importError = nil } }
             )) {
                 Button("OK") { importError = nil }
             } message: {
                 Text(importError ?? "")
+            }
+            .alert(
+                "Rename Document",
+                isPresented: .init(
+                    get: { documentPendingRename != nil },
+                    set: { if !$0 { documentPendingRename = nil } }
+                ),
+                presenting: documentPendingRename
+            ) { doc in
+                TextField("Title", text: $renameText)
+                Button("Save") {
+                    let trimmed = renameText.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !trimmed.isEmpty {
+                        doc.title = trimmed
+                        try? modelContext.save()
+                    }
+                    documentPendingRename = nil
+                }
+                Button("Cancel", role: .cancel) {
+                    documentPendingRename = nil
+                }
             }
             .alert(
                 "Delete this document?",
@@ -140,14 +204,19 @@ struct ContentView: View {
             } message: { doc in
                 Text("\"\(doc.title)\" will be permanently removed from your library.")
             }
-            .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+            .onDrop(of: [.fileURL], isTargeted: $isDropTargeted) { providers in
                 guard let provider = providers.first else { return false }
                 provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier) { data, _ in
                     guard let data = data as? Data,
                           let path = String(data: data, encoding: .utf8),
                           let url = URL(string: path) else { return }
                     let ext = url.pathExtension.lowercased()
-                    guard ext == "pdf" || ext == "epub" else { return }
+                    guard ext == "pdf" || ext == "epub" else {
+                        Task { @MainActor in
+                            importError = "\"\(url.lastPathComponent)\" isn't a supported file type. Drop a PDF or EPUB."
+                        }
+                        return
+                    }
                     Task { @MainActor in
                         importDocument(from: url)
                     }
@@ -161,33 +230,119 @@ struct ContentView: View {
     // MARK: - Custom Header
 
     private var customHeader: some View {
-        HStack {
+        HStack(spacing: 12) {
             Text("Strobe")
                 .font(StrobeTheme.titleFont(size: 32))
                 .foregroundStyle(StrobeTheme.textPrimary)
 
             Spacer()
 
-            Button {
-                showSettings = true
-            } label: {
-                Image(systemName: "gearshape.fill")
-                    .font(.system(size: 20))
-                    .foregroundStyle(StrobeTheme.textSecondary)
-                    .padding(10)
-                    .background(Color.white.opacity(0.05))
-                    .clipShape(Circle())
+            if !documents.isEmpty {
+                Menu {
+                    Picker("Sort By", selection: $librarySortOrderRaw) {
+                        ForEach(LibrarySortOrder.allCases) { order in
+                            Text(order.displayName).tag(order.rawValue)
+                        }
+                    }
+                } label: {
+                    Image(systemName: "arrow.up.arrow.down")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(StrobeTheme.textSecondary)
+                        .padding(11)
+                        .background(Color.white.opacity(0.05))
+                        .clipShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Sort library")
+                .accessibilityValue(sortOrder.displayName)
+            }
+
+            #if os(macOS)
+            SettingsLink {
+                settingsButtonLabel
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Settings")
+            #else
+            Button {
+                showSettings = true
+            } label: {
+                settingsButtonLabel
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Settings")
+            #endif
         }
         .padding(.horizontal, 24)
         .padding(.top, 16)
         .padding(.bottom, 16)
         .background(
-            StrobeTheme.background.opacity(0.8)
+            StrobeTheme.background
                 .ignoresSafeArea()
         )
+    }
+
+    private var settingsButtonLabel: some View {
+        Image(systemName: "gearshape.fill")
+            .font(.system(size: 20))
+            .foregroundStyle(StrobeTheme.textSecondary)
+            .padding(10)
+            .background(Color.white.opacity(0.05))
+            .clipShape(Circle())
+    }
+
+    // MARK: - Search
+
+    private var searchBar: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(StrobeTheme.textSecondary)
+                .font(.system(size: 14, weight: .semibold))
+
+            TextField("Search library", text: $searchText)
+                .font(StrobeTheme.bodyFont(size: 15))
+                .foregroundStyle(StrobeTheme.textPrimary)
+                .tint(StrobeTheme.accent)
+                .textFieldStyle(.plain)
+                #if os(iOS)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
+                #endif
+
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(StrobeTheme.textSecondary)
+                        .font(.system(size: 16))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(StrobeTheme.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal, 24)
+        .padding(.bottom, 4)
+        .frame(maxWidth: horizontalSizeClass == .regular ? 1024 : .infinity)
+        .frame(maxWidth: .infinity)
+    }
+
+    private var noSearchResults: some View {
+        VStack(spacing: 8) {
+            Text("No Results")
+                .font(StrobeTheme.titleFont(size: 24))
+                .foregroundStyle(StrobeTheme.textPrimary)
+
+            Text("No documents match \"\(searchText.trimmingCharacters(in: .whitespacesAndNewlines))\"")
+                .font(StrobeTheme.bodyFont(size: 16))
+                .foregroundStyle(StrobeTheme.textSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, 24)
     }
 
     private var emptyStateSubtitle: Text {
@@ -230,12 +385,21 @@ struct ContentView: View {
     private var documentGrid: some View {
         ScrollView {
             LazyVGrid(columns: columns, spacing: 16) {
-                ForEach(documents) { document in
+                ForEach(displayedDocuments) { document in
                     NavigationLink(destination: destination(for: document)) {
-                        DocumentCard(document: document, readerFont: readerFont)
+                        DocumentCard(
+                            document: document,
+                            onRename: { beginRename(document) },
+                            onDelete: { documentPendingDeletion = document }
+                        )
                     }
                     .buttonStyle(.plain)
                     .contextMenu {
+                        Button {
+                            beginRename(document)
+                        } label: {
+                            Label("Rename", systemImage: "pencil")
+                        }
                         Button(role: .destructive) {
                             documentPendingDeletion = document
                         } label: {
@@ -288,6 +452,33 @@ struct ContentView: View {
         }
     }
 
+    private func beginRename(_ document: Document) {
+        renameText = document.title
+        documentPendingRename = document
+    }
+
+}
+
+// MARK: - Library sort order
+
+/// User-selectable sort orders for the library grid, persisted in UserDefaults.
+enum LibrarySortOrder: String, CaseIterable, Identifiable {
+    static let storageKey = "librarySortOrder"
+    static let defaultValue: LibrarySortOrder = .dateAdded
+
+    case dateAdded
+    case lastRead
+    case title
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .dateAdded: "Recently Added"
+        case .lastRead: "Recently Read"
+        case .title: "Title"
+        }
+    }
 }
 
 // MARK: - Import Logic
@@ -398,7 +589,7 @@ extension ContentView {
                     .tint(.white)
 
                 Text("Importing \(importFileName)...")
-                    .font(readerFont.regularFont(size: 16))
+                    .font(StrobeTheme.bodyFont(size: 16))
                     .foregroundStyle(.white)
             }
             .padding(32)
@@ -410,41 +601,75 @@ extension ContentView {
 
 // MARK: - Document Card Component
 
-/// A grid card displaying a document's title, progress percentage, and word count.
+/// A grid card displaying a document's title, progress percentage, and word count,
+/// with a visible options menu for rename/delete (the context menu still works too).
 struct DocumentCard: View {
     let document: Document
-    let readerFont: ReaderFont
-    
+    var onRename: () -> Void = {}
+    var onDelete: () -> Void = {}
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            // Icon / Cover placeholder
-            ZStack {
-                Circle()
-                    .fill(StrobeTheme.accent.opacity(0.1))
-                    .frame(width: 48, height: 48)
-                
-                Image(systemName: "text.book.closed.fill")
-                    .font(.system(size: 20))
-                    .foregroundStyle(StrobeTheme.accent)
-            }
-            
-            Spacer()
-            
-            Text(document.title)
-                .font(StrobeTheme.titleFont(size: 18))
-                .foregroundStyle(StrobeTheme.textPrimary)
-                .lineLimit(3)
-                .minimumScaleFactor(0.9)
-                .multilineTextAlignment(.leading)
-            
-            HStack {
-                Text("\(document.progressPercentage)%")
-                    .foregroundStyle(StrobeTheme.accent)
+            HStack(alignment: .top) {
+                // Icon / Cover placeholder
+                ZStack {
+                    Circle()
+                        .fill(StrobeTheme.accent.opacity(0.1))
+                        .frame(width: 48, height: 48)
+
+                    Image(systemName: "text.book.closed.fill")
+                        .font(.system(size: 20))
+                        .foregroundStyle(StrobeTheme.accent)
+                }
+                .accessibilityHidden(true)
+
                 Spacer()
-                Text("\(document.wordCount) words")
-                    .foregroundStyle(StrobeTheme.textSecondary)
+
+                Menu {
+                    Button {
+                        onRename()
+                    } label: {
+                        Label("Rename", systemImage: "pencil")
+                    }
+                    Button(role: .destructive) {
+                        onDelete()
+                    } label: {
+                        Label("Delete", systemImage: "trash")
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 14, weight: .bold))
+                        .foregroundStyle(StrobeTheme.textSecondary)
+                        .frame(width: 30, height: 30)
+                        .background(Color.white.opacity(0.05))
+                        .clipShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Document options")
             }
-            .font(StrobeTheme.bodyFont(size: 12))
+
+            Spacer()
+
+            VStack(alignment: .leading, spacing: 12) {
+                Text(document.title)
+                    .font(StrobeTheme.titleFont(size: 18))
+                    .foregroundStyle(StrobeTheme.textPrimary)
+                    .lineLimit(3)
+                    .minimumScaleFactor(0.9)
+                    .multilineTextAlignment(.leading)
+
+                HStack {
+                    Text("\(document.progressPercentage)%")
+                        .foregroundStyle(StrobeTheme.accent)
+                    Spacer()
+                    Text("\(document.wordCount) words")
+                        .foregroundStyle(StrobeTheme.textSecondary)
+                }
+                .font(StrobeTheme.bodyFont(size: 12))
+            }
+            // Read the card as one element ("Title, 45%, 12,000 words")
+            // instead of three fragments.
+            .accessibilityElement(children: .combine)
         }
         .padding(16)
         .frame(height: 180)

--- a/Strobe/Views/ContentView.swift
+++ b/Strobe/Views/ContentView.swift
@@ -386,25 +386,31 @@ struct ContentView: View {
         ScrollView {
             LazyVGrid(columns: columns, spacing: 16) {
                 ForEach(displayedDocuments) { document in
-                    NavigationLink(destination: destination(for: document)) {
-                        DocumentCard(
-                            document: document,
-                            onRename: { beginRename(document) },
-                            onDelete: { documentPendingDeletion = document }
-                        )
-                    }
-                    .buttonStyle(.plain)
-                    .contextMenu {
-                        Button {
-                            beginRename(document)
-                        } label: {
-                            Label("Rename", systemImage: "pencil")
+                    ZStack(alignment: .topTrailing) {
+                        NavigationLink(destination: destination(for: document)) {
+                            DocumentCard(document: document)
                         }
-                        Button(role: .destructive) {
-                            documentPendingDeletion = document
-                        } label: {
-                            Label("Delete", systemImage: "trash")
+                        .buttonStyle(.plain)
+                        .contextMenu {
+                            documentMenuItems(for: document)
                         }
+
+                        // A sibling of the NavigationLink, not nested in its
+                        // label — interactive controls inside link labels are
+                        // unreliable outside Lists (the link's tap can win).
+                        Menu {
+                            documentMenuItems(for: document)
+                        } label: {
+                            Image(systemName: "ellipsis")
+                                .font(.system(size: 14, weight: .bold))
+                                .foregroundStyle(StrobeTheme.textSecondary)
+                                .frame(width: 30, height: 30)
+                                .background(Color.white.opacity(0.05))
+                                .clipShape(Circle())
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Document options")
+                        .padding(12)
                     }
                 }
             }
@@ -455,6 +461,22 @@ struct ContentView: View {
     private func beginRename(_ document: Document) {
         renameText = document.title
         documentPendingRename = document
+    }
+
+    /// Shared menu content for a document, used by both the card's visible
+    /// options menu and the long-press context menu so they can't diverge.
+    @ViewBuilder
+    private func documentMenuItems(for document: Document) -> some View {
+        Button {
+            beginRename(document)
+        } label: {
+            Label("Rename", systemImage: "pencil")
+        }
+        Button(role: .destructive) {
+            documentPendingDeletion = document
+        } label: {
+            Label("Delete", systemImage: "trash")
+        }
     }
 
 }
@@ -601,52 +623,25 @@ extension ContentView {
 
 // MARK: - Document Card Component
 
-/// A grid card displaying a document's title, progress percentage, and word count,
-/// with a visible options menu for rename/delete (the context menu still works too).
+/// A grid card displaying a document's title, progress percentage, and word
+/// count. The visible options menu is overlaid by the grid (outside the
+/// NavigationLink label); the card leaves its top-trailing corner clear for it.
 struct DocumentCard: View {
     let document: Document
-    var onRename: () -> Void = {}
-    var onDelete: () -> Void = {}
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .top) {
-                // Icon / Cover placeholder
-                ZStack {
-                    Circle()
-                        .fill(StrobeTheme.accent.opacity(0.1))
-                        .frame(width: 48, height: 48)
+            // Icon / Cover placeholder
+            ZStack {
+                Circle()
+                    .fill(StrobeTheme.accent.opacity(0.1))
+                    .frame(width: 48, height: 48)
 
-                    Image(systemName: "text.book.closed.fill")
-                        .font(.system(size: 20))
-                        .foregroundStyle(StrobeTheme.accent)
-                }
-                .accessibilityHidden(true)
-
-                Spacer()
-
-                Menu {
-                    Button {
-                        onRename()
-                    } label: {
-                        Label("Rename", systemImage: "pencil")
-                    }
-                    Button(role: .destructive) {
-                        onDelete()
-                    } label: {
-                        Label("Delete", systemImage: "trash")
-                    }
-                } label: {
-                    Image(systemName: "ellipsis")
-                        .font(.system(size: 14, weight: .bold))
-                        .foregroundStyle(StrobeTheme.textSecondary)
-                        .frame(width: 30, height: 30)
-                        .background(Color.white.opacity(0.05))
-                        .clipShape(Circle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Document options")
+                Image(systemName: "text.book.closed.fill")
+                    .font(.system(size: 20))
+                    .foregroundStyle(StrobeTheme.accent)
             }
+            .accessibilityHidden(true)
 
             Spacer()
 

--- a/Strobe/Views/PassageView.swift
+++ b/Strobe/Views/PassageView.swift
@@ -30,6 +30,12 @@ struct PassageView: View {
     /// Lazily-built lowercased copy of `words`, computed off-main on first
     /// search so each keystroke doesn't re-lowercase the whole document.
     @State private var lowercasedWords: [String]?
+    /// The in-flight lowercase pass, memoized so racing searches during the
+    /// initial build all await one pass instead of spawning duplicates.
+    @State private var lowercaseTask: Task<[String], Never>?
+    /// The query whose results `matchIndices` currently holds. Lets onSubmit
+    /// distinguish fresh matches from a stale set awaiting the debounce.
+    @State private var lastCompletedQuery: String?
     @State private var searchTask: Task<Void, Never>?
     @FocusState private var searchFocused: Bool
 
@@ -175,8 +181,13 @@ struct PassageView: View {
                 .submitLabel(.search)
                 #endif
                 .onSubmit {
-                    if !matchIndices.isEmpty {
+                    if searchQuery == lastCompletedQuery, !matchIndices.isEmpty {
                         stepMatch(by: 1)
+                    } else {
+                        // The debounced search hasn't landed for this query
+                        // yet — run it now rather than stepping through the
+                        // previous query's stale matches.
+                        runSearch(immediate: true)
                     }
                 }
                 .onChange(of: searchQuery) { _, _ in
@@ -190,6 +201,7 @@ struct PassageView: View {
                     matchIndices = []
                     matchSet = []
                     currentMatchPosition = 0
+                    lastCompletedQuery = nil
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .foregroundStyle(StrobeTheme.textSecondary)
@@ -394,7 +406,7 @@ struct PassageView: View {
         HapticManager.shared.scrubTick()
     }
 
-    private func runSearch() {
+    private func runSearch(immediate: Bool = false) {
         searchTask?.cancel()
         let query = searchQuery
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -402,31 +414,30 @@ struct PassageView: View {
             matchIndices = []
             matchSet = []
             currentMatchPosition = 0
+            lastCompletedQuery = nil
             return
         }
 
-        // Debounced: scanning (and on first search, lowercasing) every word of
-        // a long document per keystroke would jank typing on the main thread.
+        // Debounced (unless submitted explicitly): scanning every word of a
+        // long document per keystroke would waste work mid-typing. Both the
+        // one-time lowercasing and the per-query scan run off the main thread.
         searchTask = Task {
-            try? await Task.sleep(for: .milliseconds(200))
-            guard !Task.isCancelled else { return }
-
-            let lowered: [String]
-            if let cached = lowercasedWords {
-                lowered = cached
-            } else {
-                let snapshot = words
-                lowered = await Task.detached(priority: .userInitiated) {
-                    snapshot.map { $0.lowercased() }
-                }.value
+            if !immediate {
+                try? await Task.sleep(for: .milliseconds(200))
                 guard !Task.isCancelled else { return }
-                lowercasedWords = lowered
             }
 
-            let results = Self.findMatches(query: query, inLowercasedWords: lowered)
+            let lowered = await lowercasedWordsCache()
+            guard !Task.isCancelled else { return }
+
+            let (results, resultSet) = await Task.detached(priority: .userInitiated) {
+                let matches = Self.findMatches(query: query, inLowercasedWords: lowered)
+                return (matches, Set(matches))
+            }.value
             guard !Task.isCancelled, query == searchQuery else { return }
             matchIndices = results
-            matchSet = Set(results)
+            matchSet = resultSet
+            lastCompletedQuery = query
             if results.isEmpty {
                 currentMatchPosition = 0
                 return
@@ -436,6 +447,26 @@ struct PassageView: View {
             currentMatchPosition = Self.nearestMatchPosition(to: engine.currentIndex, in: results)
             scrollIntent = .matchPosition(currentMatchPosition)
         }
+    }
+
+    /// Returns the lowercased word list, building it off-main at most once.
+    /// The result is cached even when the awaiting search was cancelled —
+    /// the completed pass is valid for every future query.
+    private func lowercasedWordsCache() async -> [String] {
+        if let cached = lowercasedWords { return cached }
+        let task: Task<[String], Never>
+        if let existing = lowercaseTask {
+            task = existing
+        } else {
+            let snapshot = words
+            task = Task.detached(priority: .userInitiated) {
+                snapshot.map { $0.lowercased() }
+            }
+            lowercaseTask = task
+        }
+        let lowered = await task.value
+        lowercasedWords = lowered
+        return lowered
     }
 
     private func stepMatch(by delta: Int) {
@@ -476,14 +507,14 @@ struct PassageView: View {
     /// Case-insensitive substring search over `words`. Whitespace is trimmed
     /// from the query, and empty/whitespace-only queries yield no matches.
     /// Returned indices are sorted ascending by construction.
-    static func findMatches(query: String, in words: [String]) -> [Int] {
+    nonisolated static func findMatches(query: String, in words: [String]) -> [Int] {
         findMatches(query: query, inLowercasedWords: words.map { $0.lowercased() })
     }
 
     /// Variant of ``findMatches(query:in:)`` over pre-lowercased words, so the
     /// per-keystroke search path can reuse a cached lowercased copy instead of
     /// re-lowercasing the whole document each time.
-    static func findMatches(query: String, inLowercasedWords words: [String]) -> [Int] {
+    nonisolated static func findMatches(query: String, inLowercasedWords words: [String]) -> [Int] {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return [] }
         let needle = trimmed.lowercased()
@@ -569,8 +600,11 @@ private struct WordToken: View {
                         .fill(backgroundColor)
                 )
                 // Expand the tap target beyond the visible token — word rows
-                // are otherwise well under the 44pt minimum touch size.
-                .contentShape(Rectangle().inset(by: -4))
+                // are otherwise well under the 44pt minimum touch size. Kept
+                // at 2pt per side so expanded shapes never overlap the 5pt
+                // word gap / 6pt line gap (overlap would route edge taps to
+                // the adjacent word).
+                .contentShape(Rectangle().inset(by: -2))
         }
         .buttonStyle(.plain)
         .accessibilityLabel(text)

--- a/Strobe/Views/PassageView.swift
+++ b/Strobe/Views/PassageView.swift
@@ -568,6 +568,9 @@ private struct WordToken: View {
                     RoundedRectangle(cornerRadius: 4, style: .continuous)
                         .fill(backgroundColor)
                 )
+                // Expand the tap target beyond the visible token — word rows
+                // are otherwise well under the 44pt minimum touch size.
+                .contentShape(Rectangle().inset(by: -4))
         }
         .buttonStyle(.plain)
         .accessibilityLabel(text)

--- a/Strobe/Views/ReaderView.swift
+++ b/Strobe/Views/ReaderView.swift
@@ -24,7 +24,6 @@ struct ReaderView: View {
     @AppStorage(ReaderSettings.Keys.complexityTimingEnabled) private var complexityTimingEnabled: Bool = ReaderSettings.Defaults.complexityTimingEnabled
     @AppStorage(ReaderSettings.Keys.complexityIntensity) private var complexityIntensity: Double = ReaderSettings.Defaults.complexityIntensity
     @AppStorage(ReaderSettings.Keys.holdToReadEnabled) private var holdToReadEnabled: Bool = ReaderSettings.Defaults.holdToReadEnabled
-    @AppStorage(ReaderFont.storageKey) private var readerFontSelection = ReaderFont.defaultValue.rawValue
     @Bindable var document: Document
     @State private var engine: RSVPEngine
     @State private var isTouching = false
@@ -38,12 +37,9 @@ struct ReaderView: View {
     @State private var showChapterPicker = false
     @State private var showPassage = false
     @State private var persistenceError: String?
+    @FocusState private var readerFocused: Bool
 
     private let startingWordIndex: Int?
-
-    private var readerFont: ReaderFont {
-        ReaderFont.resolve(readerFontSelection)
-    }
 
     /// On iPad (regular width) we constrain controls to a comfortable column so
     /// sliders and buttons don't stretch the full width of a 12.9" display.
@@ -101,6 +97,13 @@ struct ReaderView: View {
                     .equatable()
                     .id("wordview") // stabilize identity
                     .transition(.opacity)
+                    // The word display sits above the gesture layer; without
+                    // this, holding directly on the word would swallow the
+                    // hold-to-read gesture.
+                    .allowsHitTesting(false)
+                    .accessibilityAction(named: engine.isPlaying ? "Pause" : "Play") {
+                        togglePlayback()
+                    }
                 }
 
                 Spacer()
@@ -117,6 +120,15 @@ struct ReaderView: View {
         #endif
         .onAppear {
             if engine.isAtEnd { showCompletion = true }
+            readerFocused = true
+        }
+        // Re-assert keyboard focus after the passage view or chapter picker
+        // closes, so Space/arrow shortcuts keep working on macOS.
+        .onChange(of: showPassage) { _, isShowing in
+            if !isShowing { readerFocused = true }
+        }
+        .onChange(of: showChapterPicker) { _, isShowing in
+            if !isShowing { readerFocused = true }
         }
         .onDisappear {
             persistState(pauseEngine: true, touchLastReadDate: true)
@@ -182,15 +194,10 @@ struct ReaderView: View {
         .preferredColorScheme(.dark)
         .focusable()
         .focusEffectDisabled()
+        .focused($readerFocused)
         .onKeyPress(.space) {
             guard !showCompletion else { return .ignored }
-            if engine.isPlaying {
-                engine.pause()
-                HapticManager.shared.playPause()
-            } else {
-                engine.play()
-                HapticManager.shared.playPause()
-            }
+            togglePlayback()
             return .handled
         }
         .onKeyPress(.leftArrow) {
@@ -318,6 +325,18 @@ struct ReaderView: View {
         pendingPlayWorkItem = nil
     }
 
+    /// Shared play/pause toggle used by the Space key and the VoiceOver
+    /// custom action, so playback isn't gesture-only.
+    private func togglePlayback() {
+        if engine.isPlaying {
+            engine.pause()
+        } else {
+            guard !engine.isAtEnd else { return }
+            engine.play()
+        }
+        HapticManager.shared.playPause()
+    }
+
     // MARK: - Top bar
 
     private var topBar: some View {
@@ -330,7 +349,6 @@ struct ReaderView: View {
         VStack(spacing: 0) {
             // Header
             HStack {
-                #if os(iOS)
                 Button {
                     dismiss()
                 } label: {
@@ -342,19 +360,19 @@ struct ReaderView: View {
                         .clipShape(Circle())
                 }
                 .buttonStyle(.plain)
-                #endif
+                .accessibilityLabel("Back")
 
                 Spacer()
 
                 VStack(spacing: 2) {
                     Text(document.title)
-                        .font(readerFont.boldFont(size: 16))
+                        .font(StrobeTheme.bodyFont(size: 16, bold: true))
                         .foregroundStyle(StrobeTheme.textPrimary)
                         .lineLimit(1)
                         .truncationMode(.tail)
 
                     Text("\(engine.currentIndex + 1) / \(engine.words.count)")
-                        .font(readerFont.regularFont(size: 12))
+                        .font(StrobeTheme.bodyFont(size: 12))
                         .foregroundStyle(StrobeTheme.textSecondary)
                 }
 
@@ -384,12 +402,12 @@ struct ReaderView: View {
             // WPM Control
             HStack {
                 Text("\(displayedWPM)")
-                    .font(readerFont.boldFont(size: 24))
+                    .font(StrobeTheme.bodyFont(size: 24, bold: true))
                     .foregroundStyle(StrobeTheme.accent)
                     .frame(width: 80)
-                
+
                 Text("wpm")
-                    .font(readerFont.regularFont(size: 14))
+                    .font(StrobeTheme.bodyFont(size: 14))
                     .foregroundStyle(StrobeTheme.textSecondary)
                     .padding(.bottom, 4)
                 
@@ -538,7 +556,7 @@ struct ReaderView: View {
             } label: {
                 HStack(spacing: 6) {
                     Text(title)
-                        .font(readerFont.boldFont(size: 13))
+                        .font(StrobeTheme.bodyFont(size: 13, bold: true))
                         .foregroundStyle(StrobeTheme.textPrimary)
                         .lineLimit(1)
                         .truncationMode(.tail)
@@ -684,21 +702,37 @@ struct ReaderView: View {
                     .foregroundStyle(StrobeTheme.textSecondary)
             }
 
-            Button {
-                withAnimation(.easeInOut(duration: 0.3)) {
-                    showCompletion = false
+            HStack(spacing: 12) {
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Done")
+                        .font(StrobeTheme.bodyFont(size: 16, bold: true))
+                        .padding(.horizontal, 28)
+                        .padding(.vertical, 16)
+                        .background(Color.white.opacity(0.08))
+                        .foregroundStyle(StrobeTheme.textPrimary)
+                        .clipShape(Capsule())
                 }
-                engine.restart()
-            } label: {
-                Text("Read Again")
-                    .font(StrobeTheme.bodyFont(size: 16, bold: true))
-                    .padding(.horizontal, 32)
-                    .padding(.vertical, 16)
-                    .background(StrobeTheme.accent)
-                    .foregroundStyle(.white)
-                    .clipShape(Capsule())
+                .buttonStyle(.plain)
+                .accessibilityHint("Return to the previous screen")
+
+                Button {
+                    withAnimation(.easeInOut(duration: 0.3)) {
+                        showCompletion = false
+                    }
+                    engine.restart()
+                } label: {
+                    Text("Read Again")
+                        .font(StrobeTheme.bodyFont(size: 16, bold: true))
+                        .padding(.horizontal, 28)
+                        .padding(.vertical, 16)
+                        .background(StrobeTheme.accent)
+                        .foregroundStyle(.white)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
             .padding(.top, 16)
         }
         .padding(40)
@@ -709,20 +743,15 @@ struct ReaderView: View {
 
     // MARK: - Hint text
 
+    // The hint lives in the bottom bar, which is hidden during playback —
+    // so only paused-state hints exist.
     private var hintText: String {
         if showCompletion { return "Completed" }
         if isBarScrubbing { return "Seeking..." }
         #if os(macOS)
-        if engine.isPlaying { return "Press Space to pause" }
         return "Press Space to read, arrows to scrub"
         #else
-        if holdToReadEnabled {
-            if engine.isPlaying { return "Release to pause" }
-            return "Hold to read"
-        } else {
-            if engine.isPlaying { return "Tap to pause" }
-            return "Tap to read"
-        }
+        return holdToReadEnabled ? "Hold to read" : "Tap to read"
         #endif
     }
 

--- a/Strobe/Views/ReaderView.swift
+++ b/Strobe/Views/ReaderView.swift
@@ -122,13 +122,12 @@ struct ReaderView: View {
             if engine.isAtEnd { showCompletion = true }
             readerFocused = true
         }
-        // Re-assert keyboard focus after the passage view or chapter picker
-        // closes, so Space/arrow shortcuts keep working on macOS.
-        .onChange(of: showPassage) { _, isShowing in
-            if !isShowing { readerFocused = true }
-        }
-        .onChange(of: showChapterPicker) { _, isShowing in
-            if !isShowing { readerFocused = true }
+        // Re-assert keyboard focus whenever any overlay (passage view, chapter
+        // picker, save-error alert) closes, so Space/arrow shortcuts keep
+        // working on macOS. One derived flag covers all presentations — adding
+        // a new one only requires extending `isPresentingOverlay`.
+        .onChange(of: isPresentingOverlay) { _, isPresenting in
+            if !isPresenting { readerFocused = true }
         }
         .onDisappear {
             persistState(pauseEngine: true, touchLastReadDate: true)
@@ -234,6 +233,12 @@ struct ReaderView: View {
         case undecided
         case reading
         case scrubbing
+    }
+
+    /// True while any focus-stealing presentation is up. Used to restore
+    /// keyboard focus when the last one closes.
+    private var isPresentingOverlay: Bool {
+        showPassage || showChapterPicker || persistenceError != nil
     }
 
     // MARK: - Unified gesture

--- a/Strobe/Views/SettingsView.swift
+++ b/Strobe/Views/SettingsView.swift
@@ -51,6 +51,10 @@ struct SettingsView: View {
 
                     Spacer()
 
+                    // iOS only: on macOS this view lives in a Settings scene,
+                    // where dismiss() has no presentation to act on — the
+                    // window's own close control is the standard affordance.
+                    #if os(iOS)
                     Button {
                         dismiss()
                     } label: {
@@ -62,6 +66,8 @@ struct SettingsView: View {
                             .clipShape(Circle())
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Close")
+                    #endif
                 }
                 .frame(maxWidth: contentMaxWidth)
                 .frame(maxWidth: .infinity)

--- a/Strobe/Views/SettingsView.swift
+++ b/Strobe/Views/SettingsView.swift
@@ -19,14 +19,11 @@ struct SettingsView: View {
 
     @State private var wpmSliderValue: Double = 300
     @State private var fontSizeSliderValue: Double = 40
+    @State private var showTutorial = false
 
     /// On iPad (regular width), constrain the settings content to a readable column width.
     private var contentMaxWidth: CGFloat {
         horizontalSizeClass == .regular ? 640 : .infinity
-    }
-
-    private var readerFont: ReaderFont {
-        ReaderFont.resolve(readerFontSelection)
     }
 
     private var currentCleaningLevel: TextCleaningLevel {
@@ -49,7 +46,7 @@ struct SettingsView: View {
                 // Header
                 HStack {
                     Text("Settings")
-                        .font(readerFont.boldFont(size: 24))
+                        .font(StrobeTheme.titleFont(size: 24))
                         .foregroundStyle(StrobeTheme.textPrimary)
 
                     Spacer()
@@ -77,16 +74,23 @@ struct SettingsView: View {
                             VStack(spacing: 16) {
                                 HStack {
                                     Text("\(defaultWPM)")
-                                        .font(readerFont.boldFont(size: 32))
+                                        .font(StrobeTheme.bodyFont(size: 32, bold: true))
                                         .foregroundStyle(StrobeTheme.accent)
                                     Text("WPM")
-                                        .font(readerFont.regularFont(size: 16))
+                                        .font(StrobeTheme.bodyFont(size: 16))
                                         .foregroundStyle(StrobeTheme.textSecondary)
                                         .padding(.bottom, 6)
                                     Spacer()
                                 }
-                                
-                                Slider(value: $wpmSliderValue, in: 100...1000, step: 10)
+
+                                VStack(spacing: 4) {
+                                    // Haptic fires once on release rather than on
+                                    // every tick of the drag.
+                                    Slider(value: $wpmSliderValue, in: 100...1000, step: 10) { editing in
+                                        if !editing {
+                                            HapticManager.shared.wpmChanged()
+                                        }
+                                    }
                                     .tint(StrobeTheme.accent)
                                     .frame(minHeight: 44)
                                     .accessibilityLabel("Default words per minute")
@@ -95,9 +99,16 @@ struct SettingsView: View {
                                         let snapped = Int(newValue)
                                         if snapped != defaultWPM {
                                             defaultWPM = snapped
-                                            HapticManager.shared.wpmChanged()
                                         }
                                     }
+
+                                    sliderRangeLabels(min: "100", max: "1000")
+                                }
+
+                                Text("Applies to newly added documents — each document keeps its own speed afterward.")
+                                    .font(StrobeTheme.bodyFont(size: 11))
+                                    .foregroundStyle(StrobeTheme.textSecondary.opacity(0.7))
+                                    .frame(maxWidth: .infinity, alignment: .leading)
                             }
                         }
 
@@ -115,7 +126,12 @@ struct SettingsView: View {
                                     Spacer()
                                 }
 
-                                Slider(value: $fontSizeSliderValue, in: 24...72, step: 2)
+                                VStack(spacing: 4) {
+                                    Slider(value: $fontSizeSliderValue, in: 24...72, step: 2) { editing in
+                                        if !editing {
+                                            HapticManager.shared.wpmChanged()
+                                        }
+                                    }
                                     .tint(StrobeTheme.accent)
                                     .frame(minHeight: 44)
                                     .accessibilityLabel("Reader text size")
@@ -124,9 +140,11 @@ struct SettingsView: View {
                                         let snapped = Int(newValue)
                                         if snapped != fontSize {
                                             fontSize = snapped
-                                            HapticManager.shared.wpmChanged()
                                         }
                                     }
+
+                                    sliderRangeLabels(min: "24", max: "72")
+                                }
                             }
                         }
 
@@ -292,20 +310,50 @@ struct SettingsView: View {
 
                         // Text Cleaning
                         settingCard(title: "Text Processing") {
-                            Toggle(isOn: textCleaningEnabled) {
-                                VStack(alignment: .leading) {
-                                    Text("Text Cleaning")
-                                        .font(StrobeTheme.bodyFont(size: 16, bold: true))
-                                        .foregroundStyle(StrobeTheme.textPrimary)
-                                    Text("Removes page numbers, headers, footers, and common boilerplate")
-                                        .font(StrobeTheme.bodyFont(size: 12))
-                                        .foregroundStyle(StrobeTheme.textSecondary)
+                            VStack(alignment: .leading, spacing: 12) {
+                                Toggle(isOn: textCleaningEnabled) {
+                                    VStack(alignment: .leading) {
+                                        Text("Text Cleaning")
+                                            .font(StrobeTheme.bodyFont(size: 16, bold: true))
+                                            .foregroundStyle(StrobeTheme.textPrimary)
+                                        Text("Removes page numbers, headers, footers, and common boilerplate")
+                                            .font(StrobeTheme.bodyFont(size: 12))
+                                            .foregroundStyle(StrobeTheme.textSecondary)
+                                    }
+                                    .frame(maxWidth: .infinity, alignment: .leading)
                                 }
-                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .tint(StrobeTheme.accent)
+                                .toggleStyle(.switch)
+
+                                Text("Applies to new imports only — existing documents aren't re-processed.")
+                                    .font(StrobeTheme.bodyFont(size: 11))
+                                    .foregroundStyle(StrobeTheme.textSecondary.opacity(0.7))
                             }
-                            .tint(StrobeTheme.accent)
-                            .toggleStyle(.switch)
                         }
+
+                        // Replay Tutorial
+                        Button {
+                            showTutorial = true
+                        } label: {
+                            HStack(spacing: 10) {
+                                Image(systemName: "arrow.counterclockwise")
+                                    .font(.system(size: 16))
+                                Text("Replay Tutorial")
+                                    .font(StrobeTheme.bodyFont(size: 16, bold: true))
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 13, weight: .semibold))
+                            }
+                            .foregroundStyle(StrobeTheme.textPrimary)
+                            .padding(16)
+                            .background(StrobeTheme.surface)
+                            .clipShape(RoundedRectangle(cornerRadius: 16))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 16)
+                                    .stroke(Color.white.opacity(0.05), lineWidth: 1)
+                            )
+                        }
+                        .buttonStyle(.plain)
 
                         // Source Code
                         Link(destination: URL(string: "https://github.com/Cuzeth/Rapid-Serial-Visual-Presentation")!) {
@@ -345,14 +393,35 @@ struct SettingsView: View {
             wpmSliderValue = Double(defaultWPM)
             fontSizeSliderValue = Double(fontSize)
         }
+        #if os(iOS)
+        .fullScreenCover(isPresented: $showTutorial) {
+            TutorialView()
+        }
+        #else
+        .sheet(isPresented: $showTutorial) {
+            TutorialView()
+                .frame(minWidth: 600, minHeight: 500)
+        }
+        #endif
     }
 
     // MARK: - Components
 
+    private func sliderRangeLabels(min: String, max: String) -> some View {
+        HStack {
+            Text(min)
+            Spacer()
+            Text(max)
+        }
+        .font(StrobeTheme.bodyFont(size: 11))
+        .foregroundStyle(StrobeTheme.textSecondary.opacity(0.7))
+        .accessibilityHidden(true)
+    }
+
     private func settingCard<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 16) {
             Text(title)
-                .font(readerFont.boldFont(size: 14))
+                .font(StrobeTheme.bodyFont(size: 14, bold: true))
                 .foregroundStyle(StrobeTheme.textSecondary)
                 .textCase(.uppercase)
                 .tracking(1)

--- a/Strobe/Views/TextInputView.swift
+++ b/Strobe/Views/TextInputView.swift
@@ -66,6 +66,7 @@ struct TextInputView: View {
                 VStack(spacing: 12) {
                     // Title field
                     TextField("Title (optional)", text: $title)
+                        .disabled(isSaving)
                         .font(StrobeTheme.bodyFont(size: 16))
                         .foregroundStyle(StrobeTheme.textPrimary)
                         .tint(StrobeTheme.accent)
@@ -90,6 +91,10 @@ struct TextInputView: View {
                         }
 
                         TextEditor(text: $inputText)
+                            // Locked during save: the save uses a snapshot of
+                            // the text, so edits made mid-save would be
+                            // silently lost when the sheet dismisses.
+                            .disabled(isSaving)
                             .scrollContentBackground(.hidden)
                             .font(StrobeTheme.bodyFont(size: 16))
                             .foregroundStyle(StrobeTheme.textPrimary)

--- a/Strobe/Views/TextInputView.swift
+++ b/Strobe/Views/TextInputView.swift
@@ -10,7 +10,15 @@ struct TextInputView: View {
     @State private var title: String = ""
     @State private var inputText: String = ""
     @State private var saveError: String?
+    @State private var isSaving = false
+    @State private var showDiscardConfirmation = false
     @FocusState private var editorFocused: Bool
+
+    /// Whether the user has typed anything worth protecting from accidental dismissal.
+    private var hasUnsavedInput: Bool {
+        !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
 
     /// Approximate word count for display.
     /// Counts CJK ideographs individually and whitespace-splits Latin text.
@@ -116,6 +124,15 @@ struct TextInputView: View {
         .onAppear {
             editorFocused = true
         }
+        .interactiveDismissDisabled(hasUnsavedInput || isSaving)
+        .confirmationDialog(
+            "Discard this text?",
+            isPresented: $showDiscardConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Discard", role: .destructive) { dismiss() }
+            Button("Keep Editing", role: .cancel) {}
+        }
         .alert("Save Error", isPresented: .init(
             get: { saveError != nil },
             set: { if !$0 { saveError = nil } }
@@ -131,7 +148,11 @@ struct TextInputView: View {
     private var header: some View {
         HStack {
             Button {
-                dismiss()
+                if hasUnsavedInput {
+                    showDiscardConfirmation = true
+                } else {
+                    dismiss()
+                }
             } label: {
                 Image(systemName: "xmark")
                     .font(.system(size: 16, weight: .bold))
@@ -141,6 +162,8 @@ struct TextInputView: View {
                     .clipShape(Circle())
             }
             .buttonStyle(.plain)
+            .disabled(isSaving)
+            .accessibilityLabel("Close")
 
             Spacer()
 
@@ -153,16 +176,23 @@ struct TextInputView: View {
             Button {
                 save()
             } label: {
-                Text("Add")
-                    .font(StrobeTheme.bodyFont(size: 16, bold: true))
-                    .foregroundStyle(canSave ? Color.white : Color.white.opacity(0.5))
-                    .padding(.horizontal, 18)
-                    .padding(.vertical, 10)
-                    .background(canSave ? StrobeTheme.accent : StrobeTheme.accent.opacity(0.35))
-                    .clipShape(Capsule())
+                HStack(spacing: 8) {
+                    if isSaving {
+                        ProgressView()
+                            .controlSize(.small)
+                            .tint(.white)
+                    }
+                    Text(isSaving ? "Adding…" : "Add")
+                        .font(StrobeTheme.bodyFont(size: 16, bold: true))
+                        .foregroundStyle(canSave ? Color.white : Color.white.opacity(0.5))
+                }
+                .padding(.horizontal, 18)
+                .padding(.vertical, 10)
+                .background(canSave ? StrobeTheme.accent : StrobeTheme.accent.opacity(0.35))
+                .clipShape(Capsule())
             }
             .buttonStyle(.plain)
-            .disabled(!canSave)
+            .disabled(!canSave || isSaving)
             .animation(.easeInOut(duration: 0.15), value: canSave)
         }
     }
@@ -170,41 +200,58 @@ struct TextInputView: View {
     // MARK: - Save
 
     private func save() {
+        guard !isSaving else { return }
         let trimmedText = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedText.isEmpty else { return }
 
-        let words = Tokenizer.tokenize(trimmedText)
-        guard !words.isEmpty else { return }
-
         let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        isSaving = true
 
-        let resolvedTitle: String
-        if trimmedTitle.isEmpty {
-            let formatter = DateFormatter()
-            formatter.dateStyle = .medium
-            formatter.timeStyle = .short
-            resolvedTitle = "Text — \(formatter.string(from: Date()))"
-        } else {
-            resolvedTitle = trimmedTitle
-        }
-        let complexityScores = WordComplexityAnalyzer.analyzeComplexity(words)
-        let document = Document(
-            title: resolvedTitle,
-            fileName: resolvedTitle,
-            bookmarkData: Data(),
-            words: words,
-            complexityScores: complexityScores,
-            wordsPerMinute: defaultWPM
-        )
-        modelContext.insert(document)
-        do {
-            try modelContext.save()
-        } catch {
-            modelContext.delete(document)
-            saveError = "Could not save: \(error.localizedDescription)"
-            return
-        }
+        Task {
+            defer { isSaving = false }
 
-        dismiss()
+            // Tokenizing and complexity analysis (NLTagger) are expensive on
+            // long pasted texts — run them off the main thread so the sheet
+            // stays responsive.
+            let (words, complexityScores) = await Task.detached(priority: .userInitiated) {
+                let words = Tokenizer.tokenize(trimmedText)
+                let scores = words.isEmpty ? [] : WordComplexityAnalyzer.analyzeComplexity(words)
+                return (words, scores)
+            }.value
+
+            guard !words.isEmpty else {
+                saveError = "No readable text found."
+                return
+            }
+
+            let resolvedTitle: String
+            if trimmedTitle.isEmpty {
+                let formatter = DateFormatter()
+                formatter.dateStyle = .medium
+                formatter.timeStyle = .short
+                resolvedTitle = "Text — \(formatter.string(from: Date()))"
+            } else {
+                resolvedTitle = trimmedTitle
+            }
+
+            let document = Document(
+                title: resolvedTitle,
+                fileName: resolvedTitle,
+                bookmarkData: Data(),
+                words: words,
+                complexityScores: complexityScores,
+                wordsPerMinute: defaultWPM
+            )
+            modelContext.insert(document)
+            do {
+                try modelContext.save()
+            } catch {
+                modelContext.delete(document)
+                saveError = "Could not save: \(error.localizedDescription)"
+                return
+            }
+
+            dismiss()
+        }
     }
 }

--- a/Strobe/Views/TutorialView.swift
+++ b/Strobe/Views/TutorialView.swift
@@ -4,16 +4,11 @@ import SwiftUI
 /// A paged walkthrough introducing import, reading controls, chapters, and settings.
 struct TutorialView: View {
     @AppStorage("hasSeenTutorial") private var hasSeenTutorial = false
-    @AppStorage(ReaderFont.storageKey) private var readerFontSelection = ReaderFont.defaultValue.rawValue
     @Environment(\.dismiss) private var dismiss
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var currentPage = 0
 
     private let pageCount = 5
-
-    private var readerFont: ReaderFont {
-        ReaderFont.resolve(readerFontSelection)
-    }
 
     var body: some View {
         ZStack {
@@ -38,6 +33,29 @@ struct TutorialView: View {
             }
             #endif
         }
+        .overlay(alignment: .topTrailing) {
+            if currentPage < pageCount - 1 {
+                skipButton
+                    .padding(20)
+            }
+        }
+    }
+
+    private var skipButton: some View {
+        Button {
+            hasSeenTutorial = true
+            dismiss()
+        } label: {
+            Text("Skip")
+                .font(StrobeTheme.bodyFont(size: 15, bold: true))
+                .foregroundStyle(StrobeTheme.textSecondary)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(Color.white.opacity(0.05))
+                .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Skip tutorial")
     }
 
     // MARK: - Page data
@@ -49,7 +67,7 @@ struct TutorialView: View {
                  description: "Speed read one word at a time, faster than ever.")
         case 1:
             page(icon: "plus.circle.fill", title: "Import Your Books",
-                 description: "Click the + button to import PDFs and EPUBs, or enter text directly.")
+                 description: importDescription)
         case 2:
             page(icon: "hand.tap.fill", title: "Reading Controls",
                  description: controlsDescription)
@@ -61,6 +79,14 @@ struct TutorialView: View {
                  description: "Adjust reading speed, font, text size, and smart timing in Settings.",
                  showButton: true)
         }
+    }
+
+    private var importDescription: String {
+        #if os(macOS)
+        "Click the + button to import PDFs and EPUBs, or enter text directly."
+        #else
+        "Tap the + button to import PDFs and EPUBs, or enter text directly."
+        #endif
     }
 
     private var controlsDescription: String {

--- a/StrobeTests/StrobeTests.swift
+++ b/StrobeTests/StrobeTests.swift
@@ -467,6 +467,23 @@ struct StrobeTests {
         #expect(lexical[3] == .noun)
     }
 
+    /// A token starting with a combining mark (common in messy PDF
+    /// extractions) merges with the preceding joiner space into a single
+    /// grapheme cluster, so a Character-counted offset table desyncs from
+    /// the joined text — every word after the malformed token then receives
+    /// its neighbor's tag. Offsets must be scalar-based to stay exact.
+    @Test(.enabled(if: StrobeTests.lexicalTaggingAvailable))
+    func complexityTagsStayAlignedAfterLeadingCombiningMark() {
+        let words = ["He", "said", "\u{0301}stop", "the", "quick", "tomorrow"]
+        let (lexical, _) = WordComplexityAnalyzer.tagText(words: words)
+
+        // Words after the combining-mark token keep their own tags instead
+        // of shifting one index back.
+        #expect(lexical[3] == .determiner)
+        #expect(lexical[4] == .adjective)
+        #expect(lexical[5] != nil)
+    }
+
     // MARK: - ORP anchor position
 
     /// The Optimal Recognition Point sits left of center, around the 1/3 mark.
@@ -671,8 +688,10 @@ struct StrobeTests {
 
     /// The per-entry decompression cap doesn't stop an archive packed with
     /// many entries from exhausting temp storage; the cumulative budget must
-    /// abort the whole extraction.
-    @Test func zipExtractorAbortsWhenTotalExtractionBudgetExceeded() throws {
+    /// bound total bytes written. Entries over the remaining budget are
+    /// skipped rather than aborting the archive, so media-heavy but
+    /// legitimate EPUBs still import.
+    @Test func zipExtractorSkipsEntriesOverTotalExtractionBudget() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -686,11 +705,13 @@ struct StrobeTests {
         let zipURL = tempDir.appendingPathComponent("test.zip")
         try buildZIPWithCentralDirectory(entries: entries).write(to: zipURL)
 
-        // Budget covers only the first two entries — extraction must throw.
+        // Budget covers only the first two entries — the third is skipped,
+        // but extraction succeeds and earlier entries are intact.
         let cappedDir = tempDir.appendingPathComponent("capped")
-        #expect(throws: DocumentImportError.epubExtractionFailed) {
-            try ZIPExtractor.extract(zipAt: zipURL, to: cappedDir, maxTotalBytes: 25)
-        }
+        try ZIPExtractor.extract(zipAt: zipURL, to: cappedDir, maxTotalBytes: 25)
+        #expect(try Data(contentsOf: cappedDir.appendingPathComponent("a.txt")) == entries[0].content)
+        #expect(try Data(contentsOf: cappedDir.appendingPathComponent("b.txt")) == entries[1].content)
+        #expect(!FileManager.default.fileExists(atPath: cappedDir.appendingPathComponent("c.txt").path))
 
         // A sufficient budget extracts everything.
         let fullDir = tempDir.appendingPathComponent("full")


### PR DESCRIPTION
## Summary
This PR adds comprehensive library management features to the ContentView, including full-text search, multiple sort orders, document renaming, and improved drag-and-drop feedback. It also refactors font handling to use the theme system consistently and improves the text input flow with unsaved changes protection.

## Key Changes

### Library Management (ContentView)
- **Search functionality**: Added `searchBar` with real-time filtering of documents by title (case-insensitive)
- **Sort orders**: New `LibrarySortOrder` enum with three options (Recently Added, Recently Read, Title) persisted via AppStorage
- **Document renaming**: Added rename dialog with confirmation, accessible via context menu and card options menu
- **Displayed documents**: New computed property that applies both sorting and search filtering to the base query
- **Drag-and-drop feedback**: Visual border appears when files are being dragged over the library, with improved error messaging for unsupported file types

### UI Improvements
- **DocumentCard refactor**: Now displays an options menu (⋯) directly on the card for rename/delete actions; removed `readerFont` parameter
- **Header updates**: Added sort menu button (visible when library is not empty), improved spacing and styling
- **Settings accessibility**: On macOS, Settings now opens via standard `SettingsLink` in the header; iOS continues using sheet presentation
- **Empty state**: New "No Results" message when search returns no documents

### Text Input (TextInputView)
- **Unsaved changes protection**: Added `hasUnsavedInput` check to prevent accidental dismissal; shows confirmation dialog if user tries to close with unsaved text
- **Async processing**: Moved expensive tokenization and complexity analysis off the main thread using `Task.detached`
- **Loading state**: Save button shows progress indicator and "Adding…" text while processing
- **Better error messaging**: More specific error for empty/unreadable text

### Font System Refactor
- **Removed `readerFontSelection` AppStorage**: Deleted unused font selection storage key from ContentView, ReaderView, TutorialView, and ChapterListView
- **Consistent theme usage**: Replaced all `readerFont.regularFont()`, `readerFont.boldFont()` calls with `StrobeTheme.bodyFont()` and `StrobeTheme.titleFont()` throughout the codebase
- **SettingsView**: Updated to use theme fonts; added explanatory text for WPM and font size sliders; added "Replay Tutorial" button

### Reader Improvements (ReaderView)
- **Keyboard focus management**: Added `@FocusState` to maintain focus after passage/chapter picker closes, ensuring Space/arrow shortcuts continue working on macOS
- **Shared play/pause logic**: New `togglePlayback()` function used by both Space key and VoiceOver custom action
- **Completion screen**: Changed "Read Again" button to "Done" (returns to library); "Read Again" moved to a separate button
- **Accessibility**: Added back button label, improved word display hit testing, added accessibility action for play/pause
- **macOS back button**: Now visible on all platforms (was iOS-only)

### Settings & Tutorial
- **Haptic feedback timing**: Sliders now fire haptics on release rather than on every drag tick
- **Slider labels**: Added min/max range labels (100/1000 for WPM, 24/72 for font size)
- **Tutorial skip button**: Added skip button in top-right corner (visible on all pages except the last)
- **Platform-specific text**: Tutorial import description now says "Tap" on iOS and "Click" on macOS
- **macOS Settings window**: Added standard Settings window accessible via Cmd+, in StrobeApp

### Bug Fixes & Polish
- **Import error alert**: Changed title from generic "Error" to "Couldn't Import File"
- **Chapter navigation**: Fixed `startingWordIndex` calculation in ChapterListView
- **Word view hit testing**: Disabled hit testing on word display so hold-to-read gesture works correctly
- **Accessibility**: Improved element combining in DocumentCard, added labels and hints throughout
- **Code cleanup**: Removed unused `readerFont` computed properties, improved spacing and formatting

## Implementation Details
- Search filtering uses `localizedC

https://claude.ai/code/session_01R7sgGLzj3Kt2xnbXJJUbdw