### PR TITLE
Cleanup pass + furthest-read progress tracking

### DIFF
--- a/Strobe.xcodeproj/project.pbxproj
+++ b/Strobe.xcodeproj/project.pbxproj
@@ -262,7 +262,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.4;
+				MARKETING_VERSION = 2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.abdeen.strobe;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -320,7 +320,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.4;
+				MARKETING_VERSION = 2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.abdeen.strobe;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Strobe/Models/Document.swift
+++ b/Strobe/Models/Document.swift
@@ -24,6 +24,11 @@ final class Document {
     @Attribute(.externalStorage) var complexityBlob: Data?
     var chapters: [Chapter]
     var currentWordIndex: Int
+    /// The furthest word index ever reached, used for progress display only —
+    /// resuming uses `currentWordIndex`. Never decreased by backward
+    /// navigation or "Read Again". The default lets stores created before
+    /// this property existed migrate lightweightly (no custom migration plan).
+    var furthestWordIndex: Int = 0
     var wordsPerMinute: Int
 
     /// Stored separately so the list view can display word count
@@ -81,10 +86,20 @@ final class Document {
         cachedWords = nil
     }
 
-    /// Reading progress as a value from 0.0 to 1.0.
+    /// The furthest-read index used for progress display. Floors at
+    /// `currentWordIndex` so documents saved before `furthestWordIndex`
+    /// existed (migrated with 0) still report the progress they had.
+    var displayedFurthestWordIndex: Int {
+        max(furthestWordIndex, currentWordIndex)
+    }
+
+    /// Reading progress as a value from 0.0 to 1.0, measured against the
+    /// furthest position ever reached — backing up to re-read doesn't
+    /// lower it.
     var progress: Double {
-        guard wordCount > 1 else { return currentWordIndex > 0 ? 1 : 0 }
-        return Double(currentWordIndex) / Double(wordCount - 1)
+        let furthest = displayedFurthestWordIndex
+        guard wordCount > 1 else { return furthest > 0 ? 1 : 0 }
+        return Double(furthest) / Double(wordCount - 1)
     }
 
     init(
@@ -107,6 +122,7 @@ final class Document {
         self.chapters = chapters
         self.wordCount = words.count
         self.currentWordIndex = currentWordIndex
+        self.furthestWordIndex = currentWordIndex
         self.wordsPerMinute = wordsPerMinute
         self.dateAdded = Date()
         self.cachedWords = words

--- a/Strobe/Utilities/Binding+Presence.swift
+++ b/Strobe/Utilities/Binding+Presence.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+extension Binding where Value == Bool {
+    /// A Boolean binding that is `true` while `source` holds a value.
+    ///
+    /// Used to drive `alert(isPresented:)` from optional state: presentation
+    /// happens by assigning the optional, and dismissing the alert (setting
+    /// the binding to `false`) clears it back to `nil`.
+    init<T>(isPresent source: Binding<T?>) {
+        self.init(
+            get: { source.wrappedValue != nil },
+            set: { if !$0 { source.wrappedValue = nil } }
+        )
+    }
+}

--- a/Strobe/Utilities/HapticManager.swift
+++ b/Strobe/Utilities/HapticManager.swift
@@ -41,8 +41,8 @@ final class HapticManager {
         notification.prepare()
     }
 
-    /// WPM slider snapped to a new value
-    func wpmChanged() {
+    /// A discrete control (e.g. a stepped slider) snapped to a new value
+    func selectionTick() {
         selection.selectionChanged()
         selection.prepare()
     }
@@ -57,7 +57,7 @@ final class HapticManager {
     func playPause() {}
     func scrubTick() {}
     func scrubBoundary() {}
-    func wpmChanged() {}
+    func selectionTick() {}
     func completedReading() {}
     #endif
 }

--- a/Strobe/Views/ChapterListView.swift
+++ b/Strobe/Views/ChapterListView.swift
@@ -4,7 +4,8 @@ import SwiftData
 /// Displays the chapter list for a document with progress indicators.
 ///
 /// Shows a "Read Full Document" option and individual chapters with
-/// not-started / in-progress / completed status based on the current reading position.
+/// not-started / in-progress / completed status based on the furthest
+/// position the user has read to.
 struct ChapterListView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -169,39 +170,47 @@ struct ChapterListView: View {
         case notStarted, inProgress, completed
     }
 
-    /// Where the reader should start when a chapter row is tapped.
-    ///
-    /// An in-progress chapter resumes at the user's current position instead of
-    /// restarting at the chapter's first word — otherwise tapping the chapter
-    /// you're partway through (and then leaving the reader) would overwrite
-    /// your saved position with the chapter start.
-    private func startingWordIndex(forChapterAt index: Int) -> Int {
-        if chapterStatus(at: index) == .inProgress {
-            return document.currentWordIndex
-        }
-        return document.chapters[index].wordIndex
-    }
-
-    private func chapterWordCount(at index: Int) -> Int {
+    /// Half-open word-index bounds of the chapter at `index`.
+    private func chapterBounds(at index: Int) -> (start: Int, end: Int) {
         let chapters = document.chapters
         let start = chapters[index].wordIndex
         let end = index + 1 < chapters.count
             ? chapters[index + 1].wordIndex
             : document.wordCount
+        return (start, end)
+    }
+
+    /// Where the reader should start when a chapter row is tapped.
+    ///
+    /// Resumes at the user's current position when it falls inside this
+    /// chapter — otherwise tapping the chapter you're partway through (and
+    /// then leaving the reader) would overwrite your saved position with the
+    /// chapter start. Judged on `currentWordIndex`, not the furthest-read
+    /// marker: status can say "in progress" for a chapter the user has read
+    /// into and then scrubbed back out of.
+    private func startingWordIndex(forChapterAt index: Int) -> Int {
+        let (start, end) = chapterBounds(at: index)
+        let current = document.currentWordIndex
+        if current > start && current < end - 1 {
+            return current
+        }
+        return start
+    }
+
+    private func chapterWordCount(at index: Int) -> Int {
+        let (start, end) = chapterBounds(at: index)
         return max(0, end - start)
     }
 
     private func chapterStatus(at index: Int) -> ChapterStatus {
-        let chapters = document.chapters
-        let start = chapters[index].wordIndex
-        let end = index + 1 < chapters.count
-            ? chapters[index + 1].wordIndex
-            : document.wordCount
-        let current = document.currentWordIndex
+        let (start, end) = chapterBounds(at: index)
+        // Judged against the furthest position ever reached, so navigating
+        // backward doesn't mark finished chapters un-finished.
+        let furthest = document.displayedFurthestWordIndex
 
-        if current >= end - 1 {
+        if furthest >= end - 1 {
             return .completed
-        } else if current > start {
+        } else if furthest > start {
             return .inProgress
         }
         return .notStarted

--- a/Strobe/Views/ContentView.swift
+++ b/Strobe/Views/ContentView.swift
@@ -285,37 +285,18 @@ struct ContentView: View {
     // MARK: - Search
 
     private var searchBar: some View {
-        HStack(spacing: 10) {
-            Image(systemName: "magnifyingglass")
-                .foregroundStyle(StrobeTheme.textSecondary)
-                .font(.system(size: 14, weight: .semibold))
-
-            TextField("Search library", text: $searchText)
-                .font(StrobeTheme.bodyFont(size: 15))
-                .foregroundStyle(StrobeTheme.textPrimary)
+        StrobeSearchBar(
+            placeholder: "Search library",
+            text: $searchText,
+            font: StrobeTheme.bodyFont(size: 15)
+        ) { field in
+            field
                 .tint(StrobeTheme.accent)
-                .textFieldStyle(.plain)
                 #if os(iOS)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled(true)
                 #endif
-
-            if !searchText.isEmpty {
-                Button {
-                    searchText = ""
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundStyle(StrobeTheme.textSecondary)
-                        .font(.system(size: 16))
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Clear search")
-            }
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .background(StrobeTheme.surface)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
         .padding(.horizontal, 24)
         .padding(.bottom, 4)
         .frame(maxWidth: horizontalSizeClass == .regular ? 1024 : .infinity)

--- a/Strobe/Views/ContentView.swift
+++ b/Strobe/Views/ContentView.swift
@@ -121,16 +121,7 @@ struct ContentView: View {
                     .presentationCornerRadius(24)
             }
             #endif
-            #if os(iOS)
-            .fullScreenCover(isPresented: $showTutorial) {
-                TutorialView()
-            }
-            #else
-            .sheet(isPresented: $showTutorial) {
-                TutorialView()
-                    .frame(minWidth: 600, minHeight: 500)
-            }
-            #endif
+            .tutorialCover(isPresented: $showTutorial)
             .sheet(isPresented: $showTextInput) {
                 TextInputView()
                     #if os(iOS)

--- a/Strobe/Views/ContentView.swift
+++ b/Strobe/Views/ContentView.swift
@@ -642,7 +642,6 @@ struct DocumentCard: View {
 
 extension Document {
     var progressPercentage: Int {
-        guard wordCount > 1 else { return currentWordIndex > 0 ? 100 : 0 }
-        return Int((Double(currentWordIndex) / Double(wordCount - 1)) * 100)
+        Int(progress * 100)
     }
 }

--- a/Strobe/Views/ContentView.swift
+++ b/Strobe/Views/ContentView.swift
@@ -156,20 +156,14 @@ struct ContentView: View {
                     importOverlay
                 }
             }
-            .alert("Couldn't Import File", isPresented: .init(
-                get: { importError != nil },
-                set: { if !$0 { importError = nil } }
-            )) {
+            .alert("Couldn't Import File", isPresented: .init(isPresent: $importError)) {
                 Button("OK") { importError = nil }
             } message: {
                 Text(importError ?? "")
             }
             .alert(
                 "Rename Document",
-                isPresented: .init(
-                    get: { documentPendingRename != nil },
-                    set: { if !$0 { documentPendingRename = nil } }
-                ),
+                isPresented: .init(isPresent: $documentPendingRename),
                 presenting: documentPendingRename
             ) { doc in
                 TextField("Title", text: $renameText)
@@ -187,10 +181,7 @@ struct ContentView: View {
             }
             .alert(
                 "Delete this document?",
-                isPresented: .init(
-                    get: { documentPendingDeletion != nil },
-                    set: { if !$0 { documentPendingDeletion = nil } }
-                ),
+                isPresented: .init(isPresent: $documentPendingDeletion),
                 presenting: documentPendingDeletion
             ) { doc in
                 Button("Delete", role: .destructive) {

--- a/Strobe/Views/PassageView.swift
+++ b/Strobe/Views/PassageView.swift
@@ -21,8 +21,9 @@ struct PassageView: View {
 
     @State private var searchQuery: String = ""
     @State private var matchIndices: [Int] = []
-    /// Mirror of `matchIndices` for O(1) per-word lookups; kept in sync wherever
-    /// `matchIndices` is assigned so chunk renders don't rebuild a Set.
+    /// Mirror of `matchIndices` for O(1) per-word lookups so chunk renders
+    /// don't rebuild a Set. Only ever assigned through ``setMatches(_:precomputedSet:)``
+    /// so it can't drift from `matchIndices`.
     @State private var matchSet: Set<Int> = []
     @State private var currentMatchPosition: Int = 0
     @State private var renderedChunks: Set<Int> = []
@@ -172,8 +173,7 @@ struct PassageView: View {
             onClear: {
                 searchTask?.cancel()
                 searchQuery = ""
-                matchIndices = []
-                matchSet = []
+                setMatches([])
                 currentMatchPosition = 0
                 lastCompletedQuery = nil
             }
@@ -390,13 +390,20 @@ struct PassageView: View {
         HapticManager.shared.scrubTick()
     }
 
+    /// Single funnel for updating the search results: assigns `matchIndices`
+    /// and its `matchSet` mirror together. `precomputedSet` lets the search
+    /// task reuse the Set it already built off the main thread.
+    private func setMatches(_ indices: [Int], precomputedSet: Set<Int>? = nil) {
+        matchIndices = indices
+        matchSet = precomputedSet ?? Set(indices)
+    }
+
     private func runSearch(immediate: Bool = false) {
         searchTask?.cancel()
         let query = searchQuery
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
-            matchIndices = []
-            matchSet = []
+            setMatches([])
             currentMatchPosition = 0
             lastCompletedQuery = nil
             return
@@ -419,8 +426,7 @@ struct PassageView: View {
                 return (matches, Set(matches))
             }.value
             guard !Task.isCancelled, query == searchQuery else { return }
-            matchIndices = results
-            matchSet = resultSet
+            setMatches(results, precomputedSet: resultSet)
             lastCompletedQuery = query
             if results.isEmpty {
                 currentMatchPosition = 0

--- a/Strobe/Views/PassageView.swift
+++ b/Strobe/Views/PassageView.swift
@@ -165,15 +165,20 @@ struct PassageView: View {
     // MARK: - Search
 
     private var searchBar: some View {
-        HStack(spacing: 10) {
-            Image(systemName: "magnifyingglass")
-                .foregroundStyle(StrobeTheme.textSecondary)
-                .font(.system(size: 14, weight: .semibold))
-
-            TextField("Search text", text: $searchQuery)
-                .font(readerFont.regularFont(size: 15))
-                .foregroundStyle(StrobeTheme.textPrimary)
-                .textFieldStyle(.plain)
+        StrobeSearchBar(
+            placeholder: "Search text",
+            text: $searchQuery,
+            font: readerFont.regularFont(size: 15),
+            onClear: {
+                searchTask?.cancel()
+                searchQuery = ""
+                matchIndices = []
+                matchSet = []
+                currentMatchPosition = 0
+                lastCompletedQuery = nil
+            }
+        ) { field in
+            field
                 .focused($searchFocused)
                 #if os(iOS)
                 .textInputAutocapitalization(.never)
@@ -193,28 +198,7 @@ struct PassageView: View {
                 .onChange(of: searchQuery) { _, _ in
                     runSearch()
                 }
-
-            if !searchQuery.isEmpty {
-                Button {
-                    searchTask?.cancel()
-                    searchQuery = ""
-                    matchIndices = []
-                    matchSet = []
-                    currentMatchPosition = 0
-                    lastCompletedQuery = nil
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundStyle(StrobeTheme.textSecondary)
-                        .font(.system(size: 16))
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Clear search")
-            }
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .background(StrobeTheme.surface)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
         .padding(.horizontal, 16)
         .padding(.bottom, 6)
     }

--- a/Strobe/Views/ReaderView.swift
+++ b/Strobe/Views/ReaderView.swift
@@ -172,10 +172,7 @@ struct ReaderView: View {
         .onChange(of: complexityIntensity) { _, newValue in
             engine.complexityIntensity = newValue
         }
-        .alert("Save Error", isPresented: .init(
-            get: { persistenceError != nil },
-            set: { if !$0 { persistenceError = nil } }
-        )) {
+        .alert("Save Error", isPresented: .init(isPresent: $persistenceError)) {
             Button("OK") { persistenceError = nil }
         } message: {
             Text(persistenceError ?? "")

--- a/Strobe/Views/ReaderView.swift
+++ b/Strobe/Views/ReaderView.swift
@@ -790,7 +790,7 @@ struct ReaderView: View {
         engine.wordsPerMinute = clamped
         document.wordsPerMinute = value
         if withHaptic {
-            HapticManager.shared.wpmChanged()
+            HapticManager.shared.selectionTick()
         }
     }
 }

--- a/Strobe/Views/ReaderView.swift
+++ b/Strobe/Views/ReaderView.swift
@@ -772,6 +772,16 @@ struct ReaderView: View {
             cancelPlayIntent()
             engine.pause()
         }
+        // The furthest-read marker only ever advances — leaving the reader
+        // after navigating backward (chapter peek, passage tap, scrubbing,
+        // "Read Again") must not erase display progress. The outgoing
+        // currentWordIndex is folded in so documents saved before the marker
+        // existed adopt their old position as the floor.
+        document.furthestWordIndex = max(
+            document.furthestWordIndex,
+            document.currentWordIndex,
+            engine.currentIndex
+        )
         document.currentWordIndex = engine.currentIndex
         document.wordsPerMinute = engine.wordsPerMinute
         if touchLastReadDate {

--- a/Strobe/Views/SettingsView.swift
+++ b/Strobe/Views/SettingsView.swift
@@ -357,16 +357,7 @@ struct SettingsView: View {
             wpmSliderValue = Double(defaultWPM)
             fontSizeSliderValue = Double(fontSize)
         }
-        #if os(iOS)
-        .fullScreenCover(isPresented: $showTutorial) {
-            TutorialView()
-        }
-        #else
-        .sheet(isPresented: $showTutorial) {
-            TutorialView()
-                .frame(minWidth: 600, minHeight: 500)
-        }
-        #endif
+        .tutorialCover(isPresented: $showTutorial)
     }
 
     // MARK: - Components

--- a/Strobe/Views/SettingsView.swift
+++ b/Strobe/Views/SettingsView.swift
@@ -94,7 +94,7 @@ struct SettingsView: View {
                                     // every tick of the drag.
                                     Slider(value: $wpmSliderValue, in: 100...1000, step: 10) { editing in
                                         if !editing {
-                                            HapticManager.shared.wpmChanged()
+                                            HapticManager.shared.selectionTick()
                                         }
                                     }
                                     .tint(StrobeTheme.accent)
@@ -135,7 +135,7 @@ struct SettingsView: View {
                                 VStack(spacing: 4) {
                                     Slider(value: $fontSizeSliderValue, in: 24...72, step: 2) { editing in
                                         if !editing {
-                                            HapticManager.shared.wpmChanged()
+                                            HapticManager.shared.selectionTick()
                                         }
                                     }
                                     .tint(StrobeTheme.accent)

--- a/Strobe/Views/SettingsView.swift
+++ b/Strobe/Views/SettingsView.swift
@@ -89,26 +89,16 @@ struct SettingsView: View {
                                     Spacer()
                                 }
 
-                                VStack(spacing: 4) {
-                                    // Haptic fires once on release rather than on
-                                    // every tick of the drag.
-                                    Slider(value: $wpmSliderValue, in: 100...1000, step: 10) { editing in
-                                        if !editing {
-                                            HapticManager.shared.selectionTick()
-                                        }
+                                snappingSlider(
+                                    value: $wpmSliderValue,
+                                    in: 100...1000,
+                                    step: 10,
+                                    accessibilityLabel: "Default words per minute",
+                                    accessibilityValue: "\(defaultWPM) words per minute"
+                                ) { snapped in
+                                    if snapped != defaultWPM {
+                                        defaultWPM = snapped
                                     }
-                                    .tint(StrobeTheme.accent)
-                                    .frame(minHeight: 44)
-                                    .accessibilityLabel("Default words per minute")
-                                    .accessibilityValue("\(defaultWPM) words per minute")
-                                    .onChange(of: wpmSliderValue) { _, newValue in
-                                        let snapped = Int(newValue)
-                                        if snapped != defaultWPM {
-                                            defaultWPM = snapped
-                                        }
-                                    }
-
-                                    sliderRangeLabels(min: "100", max: "1000")
                                 }
 
                                 Text("Applies to newly added documents — each document keeps its own speed afterward.")
@@ -132,24 +122,16 @@ struct SettingsView: View {
                                     Spacer()
                                 }
 
-                                VStack(spacing: 4) {
-                                    Slider(value: $fontSizeSliderValue, in: 24...72, step: 2) { editing in
-                                        if !editing {
-                                            HapticManager.shared.selectionTick()
-                                        }
+                                snappingSlider(
+                                    value: $fontSizeSliderValue,
+                                    in: 24...72,
+                                    step: 2,
+                                    accessibilityLabel: "Reader text size",
+                                    accessibilityValue: "\(fontSize) points"
+                                ) { snapped in
+                                    if snapped != fontSize {
+                                        fontSize = snapped
                                     }
-                                    .tint(StrobeTheme.accent)
-                                    .frame(minHeight: 44)
-                                    .accessibilityLabel("Reader text size")
-                                    .accessibilityValue("\(fontSize) points")
-                                    .onChange(of: fontSizeSliderValue) { _, newValue in
-                                        let snapped = Int(newValue)
-                                        if snapped != fontSize {
-                                            fontSize = snapped
-                                        }
-                                    }
-
-                                    sliderRangeLabels(min: "24", max: "72")
                                 }
                             }
                         }
@@ -341,44 +323,20 @@ struct SettingsView: View {
                         Button {
                             showTutorial = true
                         } label: {
-                            HStack(spacing: 10) {
-                                Image(systemName: "arrow.counterclockwise")
-                                    .font(.system(size: 16))
-                                Text("Replay Tutorial")
-                                    .font(StrobeTheme.bodyFont(size: 16, bold: true))
-                                Spacer()
-                                Image(systemName: "chevron.right")
-                                    .font(.system(size: 13, weight: .semibold))
-                            }
-                            .foregroundStyle(StrobeTheme.textPrimary)
-                            .padding(16)
-                            .background(StrobeTheme.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: 16))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 16)
-                                    .stroke(Color.white.opacity(0.05), lineWidth: 1)
+                            navigationRowLabel(
+                                icon: "arrow.counterclockwise",
+                                title: "Replay Tutorial",
+                                trailingIcon: "chevron.right"
                             )
                         }
                         .buttonStyle(.plain)
 
                         // Source Code
                         Link(destination: URL(string: "https://github.com/Cuzeth/Rapid-Serial-Visual-Presentation")!) {
-                            HStack(spacing: 10) {
-                                Image(systemName: "chevron.left.forwardslash.chevron.right")
-                                    .font(.system(size: 16))
-                                Text("View Source Code")
-                                    .font(StrobeTheme.bodyFont(size: 16, bold: true))
-                                Spacer()
-                                Image(systemName: "arrow.up.right")
-                                    .font(.system(size: 13, weight: .semibold))
-                            }
-                            .foregroundStyle(StrobeTheme.textPrimary)
-                            .padding(16)
-                            .background(StrobeTheme.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: 16))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 16)
-                                    .stroke(Color.white.opacity(0.05), lineWidth: 1)
+                            navigationRowLabel(
+                                icon: "chevron.left.forwardslash.chevron.right",
+                                title: "View Source Code",
+                                trailingIcon: "arrow.up.right"
                             )
                         }
 
@@ -412,6 +370,61 @@ struct SettingsView: View {
     }
 
     // MARK: - Components
+
+    /// A stepped settings slider with haptic-on-release, integer snapping via
+    /// `onSnap`, and min/max range labels derived from `range`.
+    private func snappingSlider(
+        value: Binding<Double>,
+        in range: ClosedRange<Double>,
+        step: Double,
+        accessibilityLabel: String,
+        accessibilityValue: String,
+        onSnap: @escaping (Int) -> Void
+    ) -> some View {
+        VStack(spacing: 4) {
+            // Haptic fires once on release rather than on
+            // every tick of the drag.
+            Slider(value: value, in: range, step: step) { editing in
+                if !editing {
+                    HapticManager.shared.selectionTick()
+                }
+            }
+            .tint(StrobeTheme.accent)
+            .frame(minHeight: 44)
+            .accessibilityLabel(accessibilityLabel)
+            .accessibilityValue(accessibilityValue)
+            .onChange(of: value.wrappedValue) { _, newValue in
+                onSnap(Int(newValue))
+            }
+
+            sliderRangeLabels(
+                min: String(Int(range.lowerBound)),
+                max: String(Int(range.upperBound))
+            )
+        }
+    }
+
+    /// Row chrome shared by "Replay Tutorial" and "View Source Code": leading
+    /// icon, bold title, and a trailing affordance icon on a surface card.
+    private func navigationRowLabel(icon: String, title: String, trailingIcon: String) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: icon)
+                .font(.system(size: 16))
+            Text(title)
+                .font(StrobeTheme.bodyFont(size: 16, bold: true))
+            Spacer()
+            Image(systemName: trailingIcon)
+                .font(.system(size: 13, weight: .semibold))
+        }
+        .foregroundStyle(StrobeTheme.textPrimary)
+        .padding(16)
+        .background(StrobeTheme.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(Color.white.opacity(0.05), lineWidth: 1)
+        )
+    }
 
     private func sliderRangeLabels(min: String, max: String) -> some View {
         HStack {

--- a/Strobe/Views/StrobeSearchBar.swift
+++ b/Strobe/Views/StrobeSearchBar.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// Shared search-bar chrome: magnifying-glass icon, plain text field, and a
+/// clear button inside a `StrobeTheme.surface` rounded rect.
+///
+/// The bare `TextField` is handed to `configureField` so each call site can
+/// attach its own focus, submit handling, and platform input modifiers
+/// without this component needing to know about them.
+struct StrobeSearchBar<Field: View>: View {
+    let placeholder: String
+    @Binding var text: String
+    let font: Font
+    /// Runs when the clear button is tapped. Defaults to clearing `text`;
+    /// call sites with extra search state to reset pass their own action.
+    var onClear: (() -> Void)? = nil
+    @ViewBuilder let configureField: (TextField<Text>) -> Field
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(StrobeTheme.textSecondary)
+                .font(.system(size: 14, weight: .semibold))
+
+            configureField(TextField(placeholder, text: $text))
+                .font(font)
+                .foregroundStyle(StrobeTheme.textPrimary)
+                .textFieldStyle(.plain)
+
+            if !text.isEmpty {
+                Button {
+                    if let onClear {
+                        onClear()
+                    } else {
+                        text = ""
+                    }
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(StrobeTheme.textSecondary)
+                        .font(.system(size: 16))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(StrobeTheme.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}

--- a/Strobe/Views/TextInputView.swift
+++ b/Strobe/Views/TextInputView.swift
@@ -138,10 +138,7 @@ struct TextInputView: View {
             Button("Discard", role: .destructive) { dismiss() }
             Button("Keep Editing", role: .cancel) {}
         }
-        .alert("Save Error", isPresented: .init(
-            get: { saveError != nil },
-            set: { if !$0 { saveError = nil } }
-        )) {
+        .alert("Save Error", isPresented: .init(isPresent: $saveError)) {
             Button("OK") { saveError = nil }
         } message: {
             Text(saveError ?? "")

--- a/Strobe/Views/TutorialView.swift
+++ b/Strobe/Views/TutorialView.swift
@@ -214,3 +214,20 @@ struct TutorialView: View {
         .padding(.horizontal, 24)
     }
 }
+
+extension View {
+    /// Presents the tutorial — full screen on iOS, a fixed-size sheet on
+    /// macOS (which has no full-screen covers).
+    func tutorialCover(isPresented: Binding<Bool>) -> some View {
+        #if os(iOS)
+        fullScreenCover(isPresented: isPresented) {
+            TutorialView()
+        }
+        #else
+        sheet(isPresented: isPresented) {
+            TutorialView()
+                .frame(minWidth: 600, minHeight: 500)
+        }
+        #endif
+    }
+}

--- a/StrobeTests/StrobeTests.swift
+++ b/StrobeTests/StrobeTests.swift
@@ -1287,4 +1287,82 @@ struct StrobeTests {
         let matches = [10, 30]
         #expect(PassageView.nearestMatchPosition(to: 20, in: matches) == 0)
     }
+
+    // MARK: - Document furthest-read progress
+
+    /// A standalone (not inserted into a container) document with `count` words.
+    private func makeDocument(wordCount count: Int) -> Document {
+        Document(
+            title: "Test",
+            fileName: "test",
+            bookmarkData: Data(),
+            words: Array(repeating: "word", count: count)
+        )
+    }
+
+    @Test func newDocumentStartsWithZeroProgress() {
+        let doc = makeDocument(wordCount: 11)
+        #expect(doc.furthestWordIndex == 0)
+        #expect(doc.progress == 0)
+        #expect(doc.progressPercentage == 0)
+    }
+
+    @Test func newDocumentSeedsFurthestFromStartingIndex() {
+        let doc = Document(
+            title: "Test",
+            fileName: "test",
+            bookmarkData: Data(),
+            words: Array(repeating: "word", count: 11),
+            currentWordIndex: 4
+        )
+        #expect(doc.furthestWordIndex == 4)
+    }
+
+    @Test func progressReflectsFurthestNotCurrentPosition() {
+        // Navigating backward (currentWordIndex behind the furthest marker)
+        // must not lower the displayed progress.
+        let doc = makeDocument(wordCount: 11)
+        doc.furthestWordIndex = 5
+        doc.currentWordIndex = 2
+        #expect(doc.displayedFurthestWordIndex == 5)
+        #expect(doc.progress == 0.5)
+        #expect(doc.progressPercentage == 50)
+    }
+
+    @Test func progressFallsBackToCurrentIndexForMigratedDocuments() {
+        // Documents saved before furthestWordIndex existed migrate with 0;
+        // display must not regress below the previously saved position.
+        let doc = makeDocument(wordCount: 11)
+        doc.currentWordIndex = 8
+        doc.furthestWordIndex = 0
+        #expect(doc.displayedFurthestWordIndex == 8)
+        #expect(doc.progress == 0.8)
+        #expect(doc.progressPercentage == 80)
+    }
+
+    @Test func progressIsCompleteAtLastWord() {
+        let doc = makeDocument(wordCount: 11)
+        doc.furthestWordIndex = 10
+        #expect(doc.progress == 1.0)
+        #expect(doc.progressPercentage == 100)
+    }
+
+    @Test func restartDoesNotResetProgress() {
+        // "Read Again" rewinds currentWordIndex to 0 while the furthest
+        // marker keeps the document showing as finished.
+        let doc = makeDocument(wordCount: 11)
+        doc.furthestWordIndex = 10
+        doc.currentWordIndex = 0
+        #expect(doc.progress == 1.0)
+    }
+
+    @Test func progressHandlesDegenerateWordCounts() {
+        let empty = makeDocument(wordCount: 0)
+        #expect(empty.progress == 0)
+
+        let single = makeDocument(wordCount: 1)
+        #expect(single.progress == 0)
+        single.furthestWordIndex = 1
+        #expect(single.progress == 1)
+    }
 }


### PR DESCRIPTION
Follow-up to #3: behavior-preserving cleanup refactors plus a small furthest-read tracking feature.

## Manual verification (task 1)

**Not performed** — this session ran in a Linux container with no Swift toolchain, Xcode, simulator, or macOS, so the two flagged behaviors (the "⋯" options button vs. NavigationLink hit-testing on iPhone, and the custom back chevron vs. system back button on macOS with `.hiddenTitleBar`) could not be verified at runtime. No speculative fixes were made; both still need a manual check on device/Mac.

## Cleanup pass (no behavior changes)

- **`StrobeSearchBar`** (new `Views/StrobeSearchBar.swift`): shared icon + plain `TextField` + clear-button chrome in a `StrobeTheme.surface` rounded rect, adopted by `ContentView.searchBar` and `PassageView.searchBar`. The bare `TextField` is passed to a `configureField` closure so each call site keeps its exact focus, autocapitalization, and submit handling; `PassageView`'s clear action (which also resets search state) is passed via `onClear`.
- **`Binding<Bool>(isPresent:)`** (new `Utilities/Binding+Presence.swift`): replaces the five hand-rolled `.init(get: { x != nil }, set: { if !$0 { x = nil } })` alert bindings in `ContentView` (×3), `TextInputView`, and `ReaderView`.
- **`SettingsView`**: the duplicated WPM/text-size slider blocks (haptic-on-release + `onChange` snap + min/max labels) collapsed into `snappingSlider(...)`; the row chrome shared by "Replay Tutorial" and "View Source Code" extracted into `navigationRowLabel(...)`.
- **`HapticManager.wpmChanged()` → `selectionTick()`**: the font-size slider fires it too, so the WPM-specific name was misleading. All call sites updated.
- **`PassageView`**: `matchIndices` and its `matchSet` mirror are now only ever assigned together through a single `setMatches(_:precomputedSet:)` funnel.
- **`tutorialCover(isPresented:)`** (in `TutorialView.swift`): shared iOS `fullScreenCover` / macOS 600×500 sheet presentation used by `ContentView` and `SettingsView`.

## Furthest-read tracking

`ReaderView.persistState` unconditionally wrote `engine.currentIndex` to `document.currentWordIndex`, so navigating backward (chapter peek, passage-view word tap, scrubbing back) and leaving the reader overwrote displayed reading progress.

- New `Document.furthestWordIndex: Int` — display only; `currentWordIndex` keeps its resume semantics untouched.
- `persistState` only ever advances it: `max(furthestWordIndex, currentWordIndex, engine.currentIndex)` (the outgoing `currentWordIndex` is folded in so migrated documents adopt their previously saved position as the floor).
- `Document.progress` / `progressPercentage` (library card, chapter list "% complete") and `ChapterListView.chapterStatus` now judge against `displayedFurthestWordIndex` = `max(furthestWordIndex, currentWordIndex)`.
- `ChapterListView.startingWordIndex` still resumes on `currentWordIndex` (only when it falls inside the tapped chapter — the furthest-based status can now say "in progress" for a chapter the user scrubbed back out of, so it no longer keys off `chapterStatus`).
- "Read Again" rewinds `currentWordIndex` but leaves the marker intact, so a finished document keeps showing 100%.
- New Swift Testing coverage for the progress computation, migration fallback, restart, and degenerate word counts.

**Migration note:** `furthestWordIndex` is declared with a default of `0` (`var furthestWordIndex: Int = 0`), so existing SwiftData stores migrate lightweightly — no custom migration plan. Migrated documents read `0` here, which is why every display path floors at `currentWordIndex`: pre-existing progress is preserved and adopted into the marker on the next save.

https://claude.ai/code/session_019AqnSJd7K8gKCMhriDkPbw

---
_Generated by [Claude Code](https://claude.ai/code/session_019AqnSJd7K8gKCMhriDkPbw)_