### PR TITLE
Hold-to-read: vertical drag adjusts reading speed

### DIFF
--- a/Strobe/Engine/RSVPEngine.swift
+++ b/Strobe/Engine/RSVPEngine.swift
@@ -278,15 +278,19 @@ final class RSVPEngine {
     /// Maps a hold-to-read vertical drag to a temporary WPM. Movement within
     /// ±15pt of the touch-down point changes nothing; beyond that dead zone,
     /// each point is worth 2.5 WPM (up = faster), measured from the dead-zone
-    /// edge, snapped to 10-WPM steps and clamped to the 100–1000 slider range.
+    /// edge. The result is always snapped to `ReaderSettings.wpmStep` and
+    /// clamped to `ReaderSettings.wpmRange`.
     nonisolated static func holdSpeedWPM(baseWPM: Int, verticalTranslation: Double) -> Int {
         let deadZone = 15.0
         let wpmPerPoint = 2.5
         let magnitude = abs(verticalTranslation)
-        guard magnitude > deadZone else { return baseWPM }
-        let delta = (magnitude - deadZone) * wpmPerPoint * (verticalTranslation < 0 ? 1 : -1)
-        let snapped = ((Double(baseWPM) + delta) / 10).rounded() * 10
-        return Int(min(1000, max(100, snapped)))
+        let delta = magnitude > deadZone
+            ? (magnitude - deadZone) * wpmPerPoint * (verticalTranslation < 0 ? 1 : -1)
+            : 0
+        let step = ReaderSettings.wpmStep
+        let snapped = ((Double(baseWPM) + delta) / step).rounded() * step
+        return Int(min(ReaderSettings.wpmRange.upperBound,
+                       max(ReaderSettings.wpmRange.lowerBound, snapped)))
     }
 
     nonisolated private static func hasTrailingPunctuation(_ word: String) -> Bool {

--- a/Strobe/Engine/RSVPEngine.swift
+++ b/Strobe/Engine/RSVPEngine.swift
@@ -23,6 +23,18 @@ final class RSVPEngine {
         didSet { onPlaybackSettingChanged() }
     }
 
+    /// Temporary speed while the hold-to-read finger drags vertically.
+    /// Cleared on `pause()` so every hold starts at `wordsPerMinute`.
+    var wpmOverride: Int? {
+        didSet { onPlaybackSettingChanged() }
+    }
+
+    /// The speed playback actually runs at: the hold override if one is
+    /// active, otherwise the configured speed.
+    var effectiveWordsPerMinute: Int {
+        wpmOverride ?? wordsPerMinute
+    }
+
     /// When enabled, longer words are displayed for proportionally more time.
     var smartTimingEnabled: Bool {
         didSet { onPlaybackSettingChanged() }
@@ -84,7 +96,7 @@ final class RSVPEngine {
     private var scheduledDeadline: DispatchTime?
 
     private var baseInterval: TimeInterval {
-        60.0 / Double(max(1, wordsPerMinute))
+        60.0 / Double(max(1, effectiveWordsPerMinute))
     }
 
     init(
@@ -134,10 +146,12 @@ final class RSVPEngine {
         scheduleNextWord()
     }
 
-    /// Stops playback and invalidates the timer.
+    /// Stops playback, invalidates the timer, and discards any hold-to-read
+    /// speed override so the next play resumes at the configured speed.
     func pause() {
         isPlaying = false
         stopTimer()
+        wpmOverride = nil
     }
 
     /// Jumps to a specific word index, clamped to valid bounds.
@@ -259,6 +273,20 @@ final class RSVPEngine {
         }
 
         return multiplier
+    }
+
+    /// Maps a hold-to-read vertical drag to a temporary WPM. Movement within
+    /// ±15pt of the touch-down point changes nothing; beyond that dead zone,
+    /// each point is worth 2.5 WPM (up = faster), measured from the dead-zone
+    /// edge, snapped to 10-WPM steps and clamped to the 100–1000 slider range.
+    nonisolated static func holdSpeedWPM(baseWPM: Int, verticalTranslation: Double) -> Int {
+        let deadZone = 15.0
+        let wpmPerPoint = 2.5
+        let magnitude = abs(verticalTranslation)
+        guard magnitude > deadZone else { return baseWPM }
+        let delta = (magnitude - deadZone) * wpmPerPoint * (verticalTranslation < 0 ? 1 : -1)
+        let snapped = ((Double(baseWPM) + delta) / 10).rounded() * 10
+        return Int(min(1000, max(100, snapped)))
     }
 
     nonisolated private static func hasTrailingPunctuation(_ word: String) -> Bool {

--- a/Strobe/Utilities/ReaderSettings.swift
+++ b/Strobe/Utilities/ReaderSettings.swift
@@ -19,6 +19,7 @@ enum ReaderSettings {
         nonisolated static let complexityTimingEnabled = "complexityTimingEnabled"
         nonisolated static let complexityIntensity = "complexityIntensity"
         nonisolated static let holdToReadEnabled = "holdToReadEnabled"
+        nonisolated static let holdSpeedAdjustEnabled = "holdSpeedAdjustEnabled"
 
         // App-level flags (not reader settings, but registered here so key
         // strings never drift between files).
@@ -36,7 +37,14 @@ enum ReaderSettings {
         nonisolated static let complexityTimingEnabled = false
         nonisolated static let complexityIntensity = 0.5
         nonisolated static let holdToReadEnabled = true
+        nonisolated static let holdSpeedAdjustEnabled = true
     }
+
+    /// Shared words-per-minute domain: the reader slider, the settings slider,
+    /// and the hold-to-read speed mapping all read these so the range and step
+    /// can never drift between call sites.
+    nonisolated static let wpmRange: ClosedRange<Double> = 100...1000
+    nonisolated static let wpmStep: Double = 10
 
     /// The engine-relevant timing settings, read directly from UserDefaults.
     struct TimingSnapshot {

--- a/Strobe/Views/ReaderView.swift
+++ b/Strobe/Views/ReaderView.swift
@@ -27,6 +27,7 @@ struct ReaderView: View {
     @AppStorage(ReaderSettings.Keys.complexityTimingEnabled) private var complexityTimingEnabled: Bool = ReaderSettings.Defaults.complexityTimingEnabled
     @AppStorage(ReaderSettings.Keys.complexityIntensity) private var complexityIntensity: Double = ReaderSettings.Defaults.complexityIntensity
     @AppStorage(ReaderSettings.Keys.holdToReadEnabled) private var holdToReadEnabled: Bool = ReaderSettings.Defaults.holdToReadEnabled
+    @AppStorage(ReaderSettings.Keys.holdSpeedAdjustEnabled) private var holdSpeedAdjustEnabled: Bool = ReaderSettings.Defaults.holdSpeedAdjustEnabled
     @Bindable var document: Document
     @State private var engine: RSVPEngine
     @State private var isTouching = false
@@ -149,6 +150,12 @@ struct ReaderView: View {
                     .allowsHitTesting(false)
                     .accessibilityAction(named: engine.isPlaying ? "Pause" : "Play") {
                         togglePlayback()
+                    }
+                    .accessibilityAction(named: "Increase speed") {
+                        nudgeSpeed(by: Int(ReaderSettings.wpmStep))
+                    }
+                    .accessibilityAction(named: "Decrease speed") {
+                        nudgeSpeed(by: -Int(ReaderSettings.wpmStep))
                     }
                 }
 
@@ -330,7 +337,7 @@ struct ReaderView: View {
                     }
                 }
 
-                if touchMode == .reading {
+                if touchMode == .reading, holdSpeedAdjustEnabled {
                     // Vertical drag while holding adjusts speed live. The
                     // override is nil inside the dead zone so the readout
                     // only appears once the finger commits to adjusting.
@@ -342,7 +349,14 @@ struct ReaderView: View {
                     )
                     if mapped != engine.effectiveWordsPerMinute {
                         engine.wpmOverride = mapped == base ? nil : mapped
-                        HapticManager.shared.scrubTick()
+                        // A distinct cue at the 100/1000 rail; otherwise the
+                        // per-step selection tick the WPM slider uses.
+                        if mapped == Int(ReaderSettings.wpmRange.lowerBound)
+                            || mapped == Int(ReaderSettings.wpmRange.upperBound) {
+                            HapticManager.shared.scrubBoundary()
+                        } else {
+                            HapticManager.shared.selectionTick()
+                        }
                     }
                 }
 
@@ -502,7 +516,7 @@ struct ReaderView: View {
                     .foregroundStyle(StrobeTheme.textSecondary)
                     .padding(.bottom, 4)
                 
-                Slider(value: $wpmSliderValue, in: 100...1000, step: 10) { editing in
+                Slider(value: $wpmSliderValue, in: ReaderSettings.wpmRange, step: ReaderSettings.wpmStep) { editing in
                     isAdjustingWPM = editing
                     if !editing {
                         applyWPM(Int(wpmSliderValue), withHaptic: true)
@@ -632,9 +646,12 @@ struct ReaderView: View {
         if showCompletion { return "Completed" }
         if isBarScrubbing { return "Seeking..." }
         #if os(macOS)
-        return "Press Space to read, arrows to scrub"
+        return holdSpeedAdjustEnabled
+            ? "Press Space to read, arrows to scrub · click-drag up/down for speed"
+            : "Press Space to read, arrows to scrub"
         #else
-        return holdToReadEnabled ? "Hold to read" : "Tap to read"
+        guard holdToReadEnabled else { return "Tap to read" }
+        return holdSpeedAdjustEnabled ? "Hold to read · drag up/down for speed" : "Hold to read"
         #endif
     }
 
@@ -677,6 +694,17 @@ struct ReaderView: View {
             HapticManager.shared.selectionTick()
         }
     }
+
+    /// Steps the configured speed by ±`wpmStep`, clamped to `wpmRange`. The
+    /// accessible, touch-mode-independent equivalent of the hold-to-read speed
+    /// drag — the WPM slider is hidden during playback, so VoiceOver / Switch
+    /// Control users and tap-to-read users otherwise have no in-playback path.
+    private func nudgeSpeed(by delta: Int) {
+        let lower = Int(ReaderSettings.wpmRange.lowerBound)
+        let upper = Int(ReaderSettings.wpmRange.upperBound)
+        let target = min(upper, max(lower, engine.wordsPerMinute + delta))
+        applyWPM(target, withHaptic: true)
+    }
 }
 
 // MARK: - Per-tick child views
@@ -703,18 +731,23 @@ private struct CurrentWordView: View {
 private struct HoldSpeedReadoutView: View {
     let engine: RSVPEngine
     @State private var isVisible = false
+    // Latched so the fade-out keeps showing the last held value instead of
+    // flicking to the base WPM when the override clears.
+    @State private var shownWPM = 0
 
     var body: some View {
-        Text("\(engine.effectiveWordsPerMinute) WPM")
+        Text("\(shownWPM) wpm")
             .font(StrobeTheme.bodyFont(size: 14))
             .monospacedDigit()
             .foregroundStyle(StrobeTheme.textSecondary)
             .opacity(isVisible ? 1 : 0)
             .task(id: engine.wpmOverride) {
-                guard engine.wpmOverride != nil else {
+                guard let override = engine.wpmOverride else {
+                    // Release: fade out quickly, keep the last shown number.
                     withAnimation(.easeInOut(duration: 0.2)) { isVisible = false }
                     return
                 }
+                shownWPM = override
                 withAnimation(.easeInOut(duration: 0.2)) { isVisible = true }
                 try? await Task.sleep(for: .seconds(2))
                 guard !Task.isCancelled else { return }

--- a/Strobe/Views/ReaderView.swift
+++ b/Strobe/Views/ReaderView.swift
@@ -698,16 +698,28 @@ private struct CurrentWordView: View {
 
 /// The transient speed readout shown while a hold-to-read vertical drag
 /// has an active WPM override. Isolates the per-change speed read.
+/// Every speed step restarts a 2s idle window; once idle, the readout
+/// fades out over 1s. Release (nil override) fades it quickly.
 private struct HoldSpeedReadoutView: View {
     let engine: RSVPEngine
+    @State private var isVisible = false
 
     var body: some View {
         Text("\(engine.effectiveWordsPerMinute) WPM")
             .font(StrobeTheme.bodyFont(size: 14))
             .monospacedDigit()
             .foregroundStyle(StrobeTheme.textSecondary)
-            .opacity(engine.wpmOverride != nil ? 1 : 0)
-            .animation(.easeInOut(duration: 0.2), value: engine.wpmOverride != nil)
+            .opacity(isVisible ? 1 : 0)
+            .task(id: engine.wpmOverride) {
+                guard engine.wpmOverride != nil else {
+                    withAnimation(.easeInOut(duration: 0.2)) { isVisible = false }
+                    return
+                }
+                withAnimation(.easeInOut(duration: 0.2)) { isVisible = true }
+                try? await Task.sleep(for: .seconds(2))
+                guard !Task.isCancelled else { return }
+                withAnimation(.easeOut(duration: 1)) { isVisible = false }
+            }
     }
 }
 

--- a/Strobe/Views/ReaderView.swift
+++ b/Strobe/Views/ReaderView.swift
@@ -136,6 +136,13 @@ struct ReaderView: View {
                     CurrentWordView(engine: engine, fontSize: CGFloat(fontSize))
                     .id("wordview") // stabilize identity
                     .transition(.opacity)
+                    // Overlay (not a sibling) so the word never shifts when
+                    // the readout appears.
+                    .overlay {
+                        HoldSpeedReadoutView(engine: engine)
+                            .offset(y: CGFloat(fontSize) * 1.4)
+                            .accessibilityHidden(true)
+                    }
                     // The word display sits above the gesture layer; without
                     // this, holding directly on the word would swallow the
                     // hold-to-read gesture.
@@ -323,6 +330,22 @@ struct ReaderView: View {
                     }
                 }
 
+                if touchMode == .reading {
+                    // Vertical drag while holding adjusts speed live. The
+                    // override is nil inside the dead zone so the readout
+                    // only appears once the finger commits to adjusting.
+                    guard engine.isPlaying else { return }
+                    let base = engine.wordsPerMinute
+                    let mapped = RSVPEngine.holdSpeedWPM(
+                        baseWPM: base,
+                        verticalTranslation: value.translation.height
+                    )
+                    if mapped != engine.effectiveWordsPerMinute {
+                        engine.wpmOverride = mapped == base ? nil : mapped
+                        HapticManager.shared.scrubTick()
+                    }
+                }
+
                 if touchMode == .scrubbing {
                     // Scrubbing is a paused-only interaction.
                     guard !engine.isPlaying else { return }
@@ -344,6 +367,9 @@ struct ReaderView: View {
                 let wasScrubbing = touchMode == .scrubbing
                 isTouching = false
                 cancelPlayIntent()
+                // pause() clears the override; this covers the not-playing
+                // edge case (e.g. the document ended mid-hold).
+                engine.wpmOverride = nil
                 if holdToReadEnabled {
                     if engine.isPlaying {
                         engine.pause()
@@ -667,6 +693,21 @@ private struct CurrentWordView: View {
     var body: some View {
         WordView(word: engine.currentWord, fontSize: fontSize)
             .equatable()
+    }
+}
+
+/// The transient speed readout shown while a hold-to-read vertical drag
+/// has an active WPM override. Isolates the per-change speed read.
+private struct HoldSpeedReadoutView: View {
+    let engine: RSVPEngine
+
+    var body: some View {
+        Text("\(engine.effectiveWordsPerMinute) WPM")
+            .font(StrobeTheme.bodyFont(size: 14))
+            .monospacedDigit()
+            .foregroundStyle(StrobeTheme.textSecondary)
+            .opacity(engine.wpmOverride != nil ? 1 : 0)
+            .animation(.easeInOut(duration: 0.2), value: engine.wpmOverride != nil)
     }
 }
 

--- a/Strobe/Views/SettingsView.swift
+++ b/Strobe/Views/SettingsView.swift
@@ -11,6 +11,7 @@ struct SettingsView: View {
     @AppStorage(ReaderSettings.Keys.complexityTimingEnabled) private var complexityTimingEnabled: Bool = ReaderSettings.Defaults.complexityTimingEnabled
     @AppStorage(ReaderSettings.Keys.complexityIntensity) private var complexityIntensity: Double = ReaderSettings.Defaults.complexityIntensity
     @AppStorage(ReaderSettings.Keys.holdToReadEnabled) private var holdToReadEnabled: Bool = ReaderSettings.Defaults.holdToReadEnabled
+    @AppStorage(ReaderSettings.Keys.holdSpeedAdjustEnabled) private var holdSpeedAdjustEnabled: Bool = ReaderSettings.Defaults.holdSpeedAdjustEnabled
     @AppStorage(ReaderFont.storageKey) private var readerFontSelection = ReaderFont.defaultValue.rawValue
     @AppStorage(TextCleaningLevel.storageKey) private var textCleaningLevel = TextCleaningLevel.defaultValue.rawValue
     @Environment(\.dismiss) private var dismiss
@@ -84,8 +85,8 @@ struct SettingsView: View {
 
                                 snappingSlider(
                                     value: $wpmSliderValue,
-                                    in: 100...1000,
-                                    step: 10,
+                                    in: ReaderSettings.wpmRange,
+                                    step: ReaderSettings.wpmStep,
                                     accessibilityLabel: "Default words per minute",
                                     accessibilityValue: "\(defaultWPM) words per minute"
                                 ) { snapped in
@@ -281,12 +282,46 @@ struct SettingsView: View {
                                     .frame(maxWidth: .infinity, alignment: .leading)
                                 }
                                 .tint(StrobeTheme.accent)
+
+                                if holdToReadEnabled {
+                                    Toggle(isOn: $holdSpeedAdjustEnabled) {
+                                        VStack(alignment: .leading) {
+                                            Text("Drag to Adjust Speed")
+                                                .font(StrobeTheme.bodyFont(size: 16, bold: true))
+                                                .foregroundStyle(StrobeTheme.textPrimary)
+                                            Text("While holding to read, drag up or down to change speed")
+                                                .font(StrobeTheme.bodyFont(size: 12))
+                                                .foregroundStyle(StrobeTheme.textSecondary)
+                                        }
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                    }
+                                    .tint(StrobeTheme.accent)
+                                    .padding(.leading, 4)
+                                    .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))
+                                }
+                                #endif
+                                #if os(macOS)
+                                Divider().background(StrobeTheme.surface)
+
+                                Toggle(isOn: $holdSpeedAdjustEnabled) {
+                                    VStack(alignment: .leading) {
+                                        Text("Drag to Adjust Speed")
+                                            .font(StrobeTheme.bodyFont(size: 16, bold: true))
+                                            .foregroundStyle(StrobeTheme.textPrimary)
+                                        Text("While reading, click-drag up or down to change speed")
+                                            .font(StrobeTheme.bodyFont(size: 12))
+                                            .foregroundStyle(StrobeTheme.textSecondary)
+                                    }
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                }
+                                .tint(StrobeTheme.accent)
                                 #endif
                             }
                             .toggleStyle(.switch)
                             .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: smartTimingEnabled)
                             .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: sentencePauseEnabled)
                             .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: complexityTimingEnabled)
+                            .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: holdToReadEnabled)
                         }
 
                         // Text Cleaning

--- a/Strobe/Views/TutorialView.swift
+++ b/Strobe/Views/TutorialView.swift
@@ -91,9 +91,9 @@ struct TutorialView: View {
 
     private var controlsDescription: String {
         #if os(macOS)
-        "Press Space to read, Space to pause. Use arrow keys or trackpad to scrub through text."
+        "Press Space to read, Space to pause. Use arrow keys or trackpad to scrub. While reading, drag up or down to adjust speed."
         #else
-        "Hold to read, release to pause. Swipe left or right to scrub. Prefer hands-free? Switch to tap-to-read in Settings."
+        "Hold to read, release to pause. Swipe left or right to scrub, or drag up and down to adjust speed. Prefer hands-free? Switch to tap-to-read in Settings."
         #endif
     }
 

--- a/StrobeTests/StrobeTests.swift
+++ b/StrobeTests/StrobeTests.swift
@@ -212,6 +212,61 @@ struct StrobeTests {
         #expect(engine.isAtEnd)
     }
 
+    // MARK: - Hold-to-read speed control
+
+    @Test func holdSpeedWPMReturnsBaseInsideDeadZone() {
+        #expect(RSVPEngine.holdSpeedWPM(baseWPM: 300, verticalTranslation: 0) == 300)
+        #expect(RSVPEngine.holdSpeedWPM(baseWPM: 300, verticalTranslation: -15) == 300)
+        #expect(RSVPEngine.holdSpeedWPM(baseWPM: 300, verticalTranslation: 15) == 300)
+    }
+
+    @Test func holdSpeedWPMIncreasesWhenMovingUp() {
+        #expect(RSVPEngine.holdSpeedWPM(baseWPM: 300, verticalTranslation: -215) == 800)
+    }
+
+    @Test func holdSpeedWPMDecreasesWhenMovingDown() {
+        #expect(RSVPEngine.holdSpeedWPM(baseWPM: 300, verticalTranslation: 55) == 200)
+    }
+
+    @Test func holdSpeedWPMSnapsToTenWPMSteps() {
+        let adjusted = RSVPEngine.holdSpeedWPM(baseWPM: 300, verticalTranslation: -21)
+        #expect(adjusted == 320)
+        #expect(RSVPEngine.holdSpeedWPM(baseWPM: 300, verticalTranslation: -19) == 310)
+    }
+
+    @Test func holdSpeedWPMClampsToSliderRange() {
+        #expect(RSVPEngine.holdSpeedWPM(baseWPM: 300, verticalTranslation: -2000) == 1000)
+        #expect(RSVPEngine.holdSpeedWPM(baseWPM: 300, verticalTranslation: 2000) == 100)
+    }
+
+    @Test func engineEffectiveWPMFollowsOverrideWithoutTouchingBase() {
+        let engine = RSVPEngine(words: ["a", "b", "c"], wordsPerMinute: 300)
+        #expect(engine.effectiveWordsPerMinute == 300)
+        engine.wpmOverride = 500
+        #expect(engine.effectiveWordsPerMinute == 500)
+        #expect(engine.wordsPerMinute == 300)
+    }
+
+    @Test func enginePauseClearsWPMOverride() {
+        let engine = RSVPEngine(words: ["a", "b", "c"], wordsPerMinute: 300)
+        engine.play()
+        engine.wpmOverride = 700
+        engine.pause()
+        #expect(engine.wpmOverride == nil)
+        #expect(engine.effectiveWordsPerMinute == 300)
+    }
+
+    @Test func engineResumesAtBaseSpeedAfterPause() {
+        let engine = RSVPEngine(words: ["a", "b", "c"], wordsPerMinute: 300)
+        engine.play()
+        engine.wpmOverride = 900
+        engine.pause()
+        engine.play()
+        #expect(engine.isPlaying)
+        #expect(engine.effectiveWordsPerMinute == 300)
+        engine.pause()
+    }
+
     // MARK: - WordStorage round-trip
 
     @Test func wordStorageEncodeDecodeRoundTrip() {

--- a/StrobeTests/StrobeTests.swift
+++ b/StrobeTests/StrobeTests.swift
@@ -239,6 +239,24 @@ struct StrobeTests {
         #expect(RSVPEngine.holdSpeedWPM(baseWPM: 300, verticalTranslation: 2000) == 100)
     }
 
+    @Test func holdSpeedWPMRoundsToNearestStep() {
+        // 312.5 → 310 (ordinary round-down; complements the -21 tie case).
+        #expect(RSVPEngine.holdSpeedWPM(baseWPM: 300, verticalTranslation: -20) == 310)
+    }
+
+    @Test func holdSpeedWPMClampsFromBoundaryBases() {
+        #expect(RSVPEngine.holdSpeedWPM(baseWPM: 1000, verticalTranslation: -50) == 1000)
+        #expect(RSVPEngine.holdSpeedWPM(baseWPM: 100, verticalTranslation: 50) == 100)
+    }
+
+    @Test func holdSpeedWPMNormalizesOffGridBaseInDeadZone() {
+        // Batch A makes the dead-zone path snap+clamp too, so an off-grid or
+        // out-of-range base normalizes even with no drag.
+        #expect(RSVPEngine.holdSpeedWPM(baseWPM: 305, verticalTranslation: 0) == 310)
+        #expect(RSVPEngine.holdSpeedWPM(baseWPM: 50, verticalTranslation: 0) == 100)
+    }
+
+    @MainActor
     @Test func engineEffectiveWPMFollowsOverrideWithoutTouchingBase() {
         let engine = RSVPEngine(words: ["a", "b", "c"], wordsPerMinute: 300)
         #expect(engine.effectiveWordsPerMinute == 300)
@@ -247,6 +265,7 @@ struct StrobeTests {
         #expect(engine.wordsPerMinute == 300)
     }
 
+    @MainActor
     @Test func enginePauseClearsWPMOverride() {
         let engine = RSVPEngine(words: ["a", "b", "c"], wordsPerMinute: 300)
         engine.play()
@@ -256,6 +275,7 @@ struct StrobeTests {
         #expect(engine.effectiveWordsPerMinute == 300)
     }
 
+    @MainActor
     @Test func engineResumesAtBaseSpeedAfterPause() {
         let engine = RSVPEngine(words: ["a", "b", "c"], wordsPerMinute: 300)
         engine.play()
@@ -264,6 +284,22 @@ struct StrobeTests {
         engine.play()
         #expect(engine.isPlaying)
         #expect(engine.effectiveWordsPerMinute == 300)
+        engine.pause()
+    }
+
+    // Base 60 WPM = 1 s/word (three words ≈ 3 s to finish). Raising the override
+    // to 6000 WPM = 10 ms/word must let playback finish well under the ~800 ms
+    // budget — impossible unless baseInterval derives from the override.
+    @MainActor
+    @Test func enginePlaybackTimerHonorsWPMOverride() async throws {
+        let engine = RSVPEngine(words: ["a", "b", "c"], wordsPerMinute: 60)
+        engine.play()
+        engine.wpmOverride = 6000
+        for _ in 0..<80 where engine.isPlaying {   // ~800 ms budget
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(engine.isAtEnd)
+        #expect(!engine.isPlaying)
         engine.pause()
     }
 


### PR DESCRIPTION
## What

While holding to read, moving the finger up increases WPM and moving it down decreases it. Releasing pauses as before; the next hold always resumes at the configured speed.

## How

- **Mapping** (`RSVPEngine.holdSpeedWPM`, pure and unit-tested): 15pt dead zone around the touch-down point, then 2.5 WPM per point measured from the dead-zone edge, snapped to 10-WPM steps (the WPM slider's granularity), clamped to the 100-1000 range. Up = faster; returning to the dead zone restores the configured speed.
- **Engine**: a new `wpmOverride` rides the existing pull-earlier timer rescheduling, so a continuous drag can never stall playback on one word. `pause()` clears the override, making resume-at-configured-speed an engine invariant. `wordsPerMinute` is never mutated by the gesture, so position/speed persistence can never capture a transient speed.
- **View**: the unified drag gesture feeds vertical translation into the override while the hold is playing, with a scrub-tick haptic per 10-WPM step. A transient "N WPM" readout is overlaid below the word (overlay, not sibling, so the word never shifts). Every speed step restarts a 2s idle window; once the speed stops changing the readout fades out over 1s, and the next change fades it back in.

Scrubbing, tap-to-toggle mode, the bottom-bar WPM slider, and macOS keyboard controls are unchanged. No new settings keys.

## Testing

8 new Swift Testing tests (dead zone, direction, slope/snapping, clamping, override semantics, pause-clears-override, resume-at-base), written test-first. Full suite passes on macOS; iOS Simulator build verified; manually tested on device.