### PR TITLE
Fix Passage View search returning zero matches for multi-word queries

### DIFF
--- a/Strobe/Views/PassageView.swift
+++ b/Strobe/Views/PassageView.swift
@@ -31,10 +31,16 @@ struct PassageView: View {
     static let chunkSize = 200
 
     @State private var searchQuery: String = ""
+    /// Start word index of each match, ascending. Phrase queries span several
+    /// words; navigation, counting, and scrolling all key off the start.
     @State private var matchIndices: [Int] = []
-    /// Mirror of `matchIndices` for O(1) per-word lookups so chunk renders
-    /// don't rebuild a Set. Only ever assigned through ``setMatches(_:precomputedSet:)``
-    /// so it can't drift from `matchIndices`.
+    /// Number of consecutive words each match covers — 1 unless the query is
+    /// a multi-word phrase.
+    @State private var matchSpan: Int = 1
+    /// Every word index inside a match, for O(1) per-word highlight lookups
+    /// so chunk renders don't rebuild a Set. Only ever assigned through
+    /// ``setMatches(_:span:precomputedSet:)`` so it can't drift from
+    /// `matchIndices`.
     @State private var matchSet: Set<Int> = []
     @State private var currentMatchPosition: Int = 0
     @State private var renderedChunks: Set<Int> = []
@@ -93,6 +99,14 @@ struct PassageView: View {
     private var currentMatchWord: Int? {
         guard !matchIndices.isEmpty, currentMatchPosition < matchIndices.count else { return nil }
         return matchIndices[currentMatchPosition]
+    }
+
+    /// Word range of the active match — one word for plain queries, the full
+    /// span for phrases. Clamped defensively; matches always fit by
+    /// construction.
+    private var currentMatchRange: Range<Int>? {
+        guard let start = currentMatchWord else { return nil }
+        return start..<min(start + matchSpan, words.count)
     }
 
     var body: some View {
@@ -297,7 +311,7 @@ struct PassageView: View {
                                 range: chunkRange(idx),
                                 currentIndex: engine.currentIndex,
                                 matchSet: matchSet,
-                                currentMatchWord: currentMatchWord,
+                                currentMatchRange: currentMatchRange,
                                 font: readerFont,
                                 onTap: handleWordTap
                             )
@@ -413,12 +427,14 @@ struct PassageView: View {
         HapticManager.shared.scrubTick()
     }
 
-    /// Single funnel for updating the search results: assigns `matchIndices`
-    /// and its `matchSet` mirror together. `precomputedSet` lets the search
-    /// task reuse the Set it already built off the main thread.
-    private func setMatches(_ indices: [Int], precomputedSet: Set<Int>? = nil) {
+    /// Single funnel for updating the search results: assigns `matchIndices`,
+    /// `matchSpan`, and the covering `matchSet` together. `precomputedSet`
+    /// lets the search task reuse the Set it already built off the main
+    /// thread.
+    private func setMatches(_ indices: [Int], span: Int = 1, precomputedSet: Set<Int>? = nil) {
         matchIndices = indices
-        matchSet = precomputedSet ?? Set(indices)
+        matchSpan = span
+        matchSet = precomputedSet ?? Self.coveredIndices(matchStarts: indices, span: span)
     }
 
     private func runSearch(immediate: Bool = false) {
@@ -444,12 +460,13 @@ struct PassageView: View {
             let lowered = await lowercasedWordsCache()
             guard !Task.isCancelled else { return }
 
-            let (results, resultSet) = await Task.detached(priority: .userInitiated) {
+            let (results, resultSet, span) = await Task.detached(priority: .userInitiated) {
                 let matches = Self.findMatches(query: query, inLowercasedWords: lowered)
-                return (matches, Set(matches))
+                let span = Self.matchSpan(for: query)
+                return (matches, Self.coveredIndices(matchStarts: matches, span: span), span)
             }.value
             guard !Task.isCancelled, query == searchQuery else { return }
-            setMatches(results, precomputedSet: resultSet)
+            setMatches(results, span: span, precomputedSet: resultSet)
             lastCompletedQuery = query
             if results.isEmpty {
                 currentMatchPosition = 0
@@ -517,9 +534,13 @@ struct PassageView: View {
         return max(0, min(wordIndex / chunkSize, count - 1))
     }
 
-    /// Case-insensitive substring search over `words`. Whitespace is trimmed
-    /// from the query, and empty/whitespace-only queries yield no matches.
-    /// Returned indices are sorted ascending by construction.
+    /// Case-insensitive search over `words`. A single-word query matches as a
+    /// substring inside any word; a query containing whitespace matches as a
+    /// phrase across consecutive words, exactly as the phrase reads in the
+    /// space-joined passage text. Empty/whitespace-only queries yield no
+    /// matches. Returned indices are the first word of each match, sorted
+    /// ascending by construction; each match covers ``matchSpan(for:)``
+    /// consecutive words.
     nonisolated static func findMatches(query: String, in words: [String]) -> [Int] {
         findMatches(query: query, inLowercasedWords: words.map { $0.lowercased() })
     }
@@ -528,15 +549,57 @@ struct PassageView: View {
     /// per-keystroke search path can reuse a cached lowercased copy instead of
     /// re-lowercasing the whole document each time.
     nonisolated static func findMatches(query: String, inLowercasedWords words: [String]) -> [Int] {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return [] }
-        let needle = trimmed.lowercased()
+        let tokens = queryTokens(query)
+        guard let first = tokens.first else { return [] }
         var results: [Int] = []
         results.reserveCapacity(min(words.count, 256))
-        for (i, word) in words.enumerated() where word.contains(needle) {
-            results.append(i)
+
+        if tokens.count == 1 {
+            for (i, word) in words.enumerated() where word.contains(first) {
+                results.append(i)
+            }
+            return results
+        }
+
+        // Phrase query: the passage renders words separated by single spaces,
+        // so the query matches wherever it occurs as a substring of that
+        // joined text — the first token must end a word, middle tokens must
+        // equal whole words, and the last token must begin the word after.
+        let lastOffset = tokens.count - 1
+        guard words.count >= tokens.count else { return [] }
+        starts: for start in 0...(words.count - tokens.count) {
+            guard words[start].hasSuffix(first),
+                  words[start + lastOffset].hasPrefix(tokens[lastOffset]) else { continue }
+            for k in 1..<lastOffset where words[start + k] != tokens[k] {
+                continue starts
+            }
+            results.append(start)
         }
         return results
+    }
+
+    /// Number of consecutive words each match of `query` covers: 1 for
+    /// single-word queries, the token count for phrase queries.
+    nonisolated static func matchSpan(for query: String) -> Int {
+        max(1, queryTokens(query).count)
+    }
+
+    /// Every word index inside a match, given the match start indices and the
+    /// per-match span — the set driving per-word highlight lookups.
+    nonisolated static func coveredIndices(matchStarts: [Int], span: Int) -> Set<Int> {
+        guard span > 1 else { return Set(matchStarts) }
+        var covered = Set<Int>(minimumCapacity: matchStarts.count * span)
+        for start in matchStarts {
+            for i in start..<(start + span) { covered.insert(i) }
+        }
+        return covered
+    }
+
+    /// Lowercased whitespace-separated tokens of `query`; empty for
+    /// whitespace-only queries. Splitting also normalizes runs of interior
+    /// whitespace, mirroring how the tokenizer collapsed the document text.
+    nonisolated private static func queryTokens(_ query: String) -> [String] {
+        query.lowercased().split(whereSeparator: \.isWhitespace).map(String.init)
     }
 
     /// Whether the words are dominantly right-to-left script (Arabic or
@@ -592,7 +655,7 @@ private struct WordChunkView: View {
     let range: Range<Int>
     let currentIndex: Int
     let matchSet: Set<Int>
-    let currentMatchWord: Int?
+    let currentMatchRange: Range<Int>?
     let font: ReaderFont
     let onTap: (Int) -> Void
 
@@ -602,7 +665,7 @@ private struct WordChunkView: View {
                 WordToken(
                     text: words[i],
                     isCurrent: i == currentIndex,
-                    isPrimaryMatch: i == currentMatchWord,
+                    isPrimaryMatch: currentMatchRange?.contains(i) ?? false,
                     isMatch: matchSet.contains(i),
                     font: font
                 ) {

--- a/StrobeTests/StrobeTests.swift
+++ b/StrobeTests/StrobeTests.swift
@@ -1329,12 +1329,87 @@ struct StrobeTests {
         #expect(PassageView.findMatches(query: "delta", in: words).isEmpty)
     }
 
+    // Issue #6: queries containing whitespace always returned zero matches
+    // because each word was tested for containing the space-joined needle.
+
+    @Test func findMatchesPhraseAcrossConsecutiveWords() {
+        let words = ["we", "ate", "banana", "pie", "today"]
+        #expect(PassageView.findMatches(query: "banana pie", in: words) == [2])
+        #expect(PassageView.findMatches(query: "ate banana pie", in: words) == [1])
+    }
+
+    @Test func findMatchesPhraseIsCaseInsensitive() {
+        let words = ["Banana", "Pie"]
+        #expect(PassageView.findMatches(query: "banana PIE", in: words) == [0])
+    }
+
+    @Test func findMatchesPhraseAllowsTrailingPunctuationOnLastWord() {
+        // Tokenized words keep punctuation attached; "pie." still begins
+        // with "pie", matching how the passage text reads.
+        let words = ["we", "ate", "banana", "pie.", "yum"]
+        #expect(PassageView.findMatches(query: "banana pie", in: words) == [2])
+    }
+
+    @Test func findMatchesPhraseUsesSuffixAndPrefixAtBoundaries() {
+        // Substring-of-passage semantics: the first token may end a word and
+        // the last may begin one — "na pie" occurs inside "banana pies".
+        let words = ["banana", "pies"]
+        #expect(PassageView.findMatches(query: "na pie", in: words) == [0])
+    }
+
+    @Test func findMatchesPhraseRequiresExactMiddleWords() {
+        let words = ["big", "banana", "cream", "pie"]
+        #expect(PassageView.findMatches(query: "banana cream pie", in: words) == [1])
+        #expect(PassageView.findMatches(query: "banana creamy pie", in: words).isEmpty)
+        // Punctuation between the words means the passage doesn't read as the
+        // queried phrase, so strict adjacency correctly rejects it.
+        let punctuated = ["big", "banana,", "cream", "pie"]
+        #expect(PassageView.findMatches(query: "banana cream pie", in: punctuated).isEmpty)
+    }
+
+    @Test func findMatchesPhraseFindsOverlappingOccurrences() {
+        let words = ["fish", "fish", "fish"]
+        #expect(PassageView.findMatches(query: "fish fish", in: words) == [0, 1])
+    }
+
+    @Test func findMatchesPhraseNormalizesInteriorWhitespace() {
+        let words = ["banana", "pie"]
+        #expect(PassageView.findMatches(query: "  banana   pie  ", in: words) == [0])
+    }
+
+    @Test func findMatchesPhraseLongerThanDocumentIsEmpty() {
+        let words = ["banana"]
+        #expect(PassageView.findMatches(query: "banana pie", in: words).isEmpty)
+        #expect(PassageView.findMatches(query: "a b", in: []).isEmpty)
+    }
+
+    @Test func findMatchesPhraseSupportsCJKWords() {
+        let words = ["你好", "世界", "你好啊"]
+        #expect(PassageView.findMatches(query: "你好 世界", in: words) == [0])
+    }
+
+    @Test func matchSpanCountsQueryTokens() {
+        #expect(PassageView.matchSpan(for: "banana") == 1)
+        #expect(PassageView.matchSpan(for: "banana pie") == 2)
+        #expect(PassageView.matchSpan(for: "  banana   cream  pie ") == 3)
+        #expect(PassageView.matchSpan(for: "") == 1)
+        #expect(PassageView.matchSpan(for: "   ") == 1)
+    }
+
+    @Test func coveredIndicesSpanEveryMatchedWord() {
+        #expect(PassageView.coveredIndices(matchStarts: [2, 7], span: 2) == [2, 3, 7, 8])
+        #expect(PassageView.coveredIndices(matchStarts: [1], span: 1) == [1])
+        #expect(PassageView.coveredIndices(matchStarts: [0, 1], span: 2) == [0, 1, 2])
+        #expect(PassageView.coveredIndices(matchStarts: [], span: 3).isEmpty)
+    }
+
     /// The per-keystroke search path uses a cached lowercased copy of the
     /// words; the pre-lowered overload must agree with the general one.
     @Test func findMatchesLowercasedOverloadAgreesWithGeneralOverload() {
         let words = ["Hello", "WORLD", "hello", "don't", "end.", "你好啊"]
         let lowered = words.map { $0.lowercased() }
-        for query in ["HELLO", "world", "don", "end", "你好", "missing", "  quick  ", ""] {
+        for query in ["HELLO", "world", "don", "end", "你好", "missing", "  quick  ", "",
+                      "hello world", "WORLD hello", "the end", "missing phrase"] {
             #expect(
                 PassageView.findMatches(query: query, inLowercasedWords: lowered)
                     == PassageView.findMatches(query: query, in: words),


### PR DESCRIPTION
Fixes #6

## Problem

In the Passage View, the in-text search always reported **0 matches** for any query containing whitespace (e.g. `banana pie`), even when the phrase clearly existed in the document. Single-word queries worked fine.

## Root cause

`PassageView.findMatches` searched the *tokenized word list* by testing each individual word for containing the query as a substring:

```swift
for (i, word) in words.enumerated() where word.contains(needle) {
```

Words are produced by splitting on whitespace, so no single word can ever contain a space — any multi-word query was structurally guaranteed to return zero matches, for every document type.

## Fix

Queries containing whitespace are now treated as **phrase queries** matched across consecutive words, using substring-of-passage semantics (the passage renders words joined by single spaces):

- the first token must **end** a word (`hasSuffix`),
- middle tokens must **equal** whole words,
- the last token must **begin** the following word (`hasPrefix`).

So `banana pie` matches `…banana pie.…` and even `na pie` inside `banana pies`, while `banana, pie` in the text correctly does *not* match `banana pie` (the passage doesn't read that way). Single-word queries keep their exact existing substring behavior.

Match indices are the first word of each phrase occurrence, so the match counter, prev/next navigation, nearest-match selection, and scroll targeting all keep working unchanged. Highlighting now covers **every word of a matched span** — both the faded highlight for all matches and the solid primary highlight for the active one (`WordChunkView` takes a `currentMatchRange` instead of a single word index).

## Tests

Added Swift Testing coverage for: basic 2- and 3-token phrases, case-insensitivity, trailing punctuation on the final word, suffix/prefix boundary matching, exact-middle-word requirement (incl. punctuation rejection), overlapping occurrences, interior whitespace normalization, phrase longer than document, CJK phrases, `matchSpan`, `coveredIndices`, and phrase queries in the lowercased-overload agreement test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)