### PR TITLE
CI: overlap simulator boot with build, xcbeautify, job timeouts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ jobs:
   test-ios:
     name: iOS Tests
     runs-on: macos-26
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v5
@@ -72,6 +73,12 @@ jobs:
           )
           echo "Selected simulator: $UDID"
           echo "udid=$UDID" >> "$GITHUB_OUTPUT"
+          # Start booting now so the slow simulator boot overlaps the build
+          # phase instead of serializing after it — `simctl boot` returns as
+          # soon as the boot is underway, and xcodebuild attaches to a
+          # booting/booted device without restarting it. This was the silent
+          # multi-minute gap after the build finished.
+          xcrun simctl boot "$UDID" || true
 
       - name: Run tests
         run: |
@@ -82,8 +89,7 @@ jobs:
             -destination "platform=iOS Simulator,id=${{ steps.simulator.outputs.udid }}" \
             -resultBundlePath TestResults.xcresult \
             -skipPackagePluginValidation \
-            -skip-testing:StrobeUITests \
-            CODE_SIGNING_ALLOWED=NO | xcpretty --color
+            CODE_SIGNING_ALLOWED=NO | xcbeautify --renderer github-actions
 
       - name: Upload test results
         if: failure()
@@ -95,6 +101,7 @@ jobs:
   test-macos:
     name: macOS Tests
     runs-on: macos-26
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v5
@@ -108,7 +115,7 @@ jobs:
             -destination 'platform=macOS' \
             -resultBundlePath TestResults-macOS.xcresult \
             -skipPackagePluginValidation \
-            CODE_SIGNING_ALLOWED=NO | xcpretty --color
+            CODE_SIGNING_ALLOWED=NO | xcbeautify --renderer github-actions
 
       - name: Upload test results
         if: failure()


### PR DESCRIPTION
## Why

iOS test job step timings run 208–321s while the macOS job finishes in 43–66s — the entire gap is xcodebuild booting the simulator and installing the test host **serially after** the build, a silent multi-minute stall right after `Touching Strobe.app` (xcpretty prints nothing during it). The occasional 15+ minute wall-clock runs are mostly GitHub macOS runner queue time on top of that (e.g. one 16.2-min run executed for only 5.8 + 0.8 min).

## Changes

- **Boot the simulator right after selecting it** (`xcrun simctl boot "$UDID" || true`): `simctl boot` returns once boot is underway, so the boot overlaps the ~1.5-min build phase and xcodebuild attaches to a warm device instead of cold-booting one at run time. Expected to cut roughly 1.5–2.5 min off the iOS job.
- **Swap `xcpretty` for preinstalled `xcbeautify --renderer github-actions`**: streams output during previously-silent phases and surfaces build/test failures as inline GitHub annotations. xcpretty is unmaintained.
- **Remove `-skip-testing:StrobeUITests`**: the project contains no such target — the flag was a no-op.
- **Add `timeout-minutes: 15` to both jobs**: a hung simulator can no longer hold a runner for hours (slowest observed job execution is 5.8 min).

This PR's own CI run demonstrates the new timings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)