### PR TITLE
CI: run iOS tests on the pre-booted simulator instead of a cold clone

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,12 +83,17 @@ jobs:
       - name: Run tests
         run: |
           set -o pipefail
+          # Parallel testing makes xcodebuild boot a fresh *clone* of the
+          # destination (log: "Clone 1 of iPhone 17 Pro"), discarding the
+          # pre-booted device — and with a single unit-test bundle it only
+          # ever creates one worker anyway. Run directly on the booted sim.
           xcodebuild test \
             -project Strobe.xcodeproj \
             -scheme Strobe \
             -destination "platform=iOS Simulator,id=${{ steps.simulator.outputs.udid }}" \
             -resultBundlePath TestResults.xcresult \
             -skipPackagePluginValidation \
+            -parallel-testing-enabled NO \
             CODE_SIGNING_ALLOWED=NO | xcbeautify --renderer github-actions
 
       - name: Upload test results


### PR DESCRIPTION
Follow-up to #9, from measuring its first run on main.

## What the logs showed

xcodebuild's own phase metric (`IDETestOperationsObserverDebug: … elapsed -- Testing started`):

| Run | Boot→test phase |
|---|---|
| Before #9 (no pre-boot) | **172s** |
| After #9 (pre-boot) | **99s** |

The pre-boot helped, but the run log revealed why 99s remained: tests executed on **"Clone 1 of iPhone 17 Pro"** — xcodebuild's parallel-testing mode boots a *fresh clone* of the destination rather than using the pre-booted device. And with a single unit-test bundle it only ever creates **one** worker, so the clone boot is pure overhead with zero added parallelism.

`-parallel-testing-enabled NO` makes the tests attach directly to the warm, pre-booted simulator. Swift Testing's in-process test parallelism is unaffected. The macOS job is untouched (no simulators involved there).

Note: the #9 run totals looked slow (364s test step) because that runner draw was slow across the board — the unchanged macOS job also ran 75s vs its 43–66s baseline. The phase metric above is the honest comparison, and this PR's CI run will show it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)