### PR TITLE
Smart timing: configurable minimum word length before slowdown applies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ PDF/EPUB/Text → DocumentImportPipeline → Extractor → TextCleaner → Token
 - CJK text: detected by Unicode range, segmented via `NLTokenizer`, punctuation attached to preceding word
 - Mixed-script text: character-by-character buffering switches between Latin and CJK
 
-**RSVPEngine** (`Engine/RSVPEngine.swift`): `@Observable` class driving timer-based word advancement. Supports smart timing (duration scales with word length), sentence pauses (multiplier at sentence-ending punctuation across Latin, CJK, and Arabic scripts), and complexity timing (per-word duration modulation based on cognitive complexity scores).
+**RSVPEngine** (`Engine/RSVPEngine.swift`): `@Observable` class driving timer-based word advancement. Supports smart timing (duration scales with word length; a configurable minimum word length keeps shorter words at the base rate), sentence pauses (multiplier at sentence-ending punctuation across Latin, CJK, and Arabic scripts), and complexity timing (per-word duration modulation based on cognitive complexity scores).
 
 **WordComplexityAnalyzer** (`Engine/WordComplexityAnalyzer.swift`): Scores each word's cognitive complexity (0.0–1.0) using NLTagger lexical class, named entity recognition, word frequency (built-in common word list), character composition, and word length. Scores are computed at import time and stored as a parallel `[Float]` blob via `ComplexityStorage`.
 
@@ -68,7 +68,7 @@ Strobe/
 - **Theme**: Dark mode only, background `0x050505`, accent "Strobe Red" `#FF3B30`
 - **Typography**: Fraunces (`titleFont`) for headings and for large display numerals in Settings cards (WPM, text size — `titleFont(size: 32)` in `textPrimary`); body text and captions use `bodyFont`. Keep sibling numerals styled identically.
 - **Error types**: `DocumentImportError` enum (`unsupportedFileType`, `epubExtractionFailed`, `epubDRMProtected`, `pdfLoadFailed`, `pdfPasswordProtected`, `noReadableText`)
-- **Settings keys**: `defaultWPM`, `fontSize`, `smartTimingEnabled`, `sentencePauseEnabled`, `smartTimingPercentPerLetter`, `sentencePauseMultiplier`, `complexityTimingEnabled`, `complexityIntensity`, `holdToReadEnabled`, `readerFontSelection`, `textCleaningLevel` — all registered in `ReaderSettings.Keys` (plus app flags `hasSeenTutorial`, `didCompactLegacyWordStorage`); never use raw key strings
+- **Settings keys**: `defaultWPM`, `fontSize`, `smartTimingEnabled`, `sentencePauseEnabled`, `smartTimingPercentPerLetter`, `smartTimingMinimumWordLength`, `sentencePauseMultiplier`, `complexityTimingEnabled`, `complexityIntensity`, `holdToReadEnabled`, `holdSpeedAdjustEnabled`, `readerFontSelection`, `textCleaningLevel` — all registered in `ReaderSettings.Keys` (plus app flags `hasSeenTutorial`, `didCompactLegacyWordStorage`); never use raw key strings
 - **Navigation**: value-based (`NavigationLink(value:)` + `navigationDestination` in `ContentView`, `ReaderRoute` for chapter entries) — eager `destination:` links would decode word blobs for every visible row. `ReaderView` loads word blobs asynchronously in `.task`, never in `init`.
 - **Platform conditionals**: `#if os(iOS)` / `#if os(macOS)` for UIKit/AppKit imports, haptics, presentation modifiers, and hint text. Engine, import pipeline, and models are fully cross-platform.
 - **macOS keyboard shortcuts**: Space (play/pause), Left/Right arrows (scrub), Escape (dismiss reader) — via `.onKeyPress`, also works on iPad with hardware keyboard

--- a/Strobe/Engine/RSVPEngine.swift
+++ b/Strobe/Engine/RSVPEngine.swift
@@ -51,6 +51,13 @@ final class RSVPEngine {
         didSet { onPlaybackSettingChanged() }
     }
 
+    /// Minimum letter count (punctuation excluded) a word needs before the
+    /// per-letter slowdown applies; shorter words display at the base rate so
+    /// the overall pace stays close to the configured WPM. 1 slows every word.
+    var smartTimingMinimumWordLength: Int {
+        didSet { onPlaybackSettingChanged() }
+    }
+
     /// Multiplier applied to the interval at sentence-ending punctuation when sentence pauses are on.
     var sentencePauseMultiplier: Double {
         didSet { onPlaybackSettingChanged() }
@@ -106,6 +113,7 @@ final class RSVPEngine {
         smartTimingEnabled: Bool = false,
         sentencePauseEnabled: Bool = false,
         smartTimingPercentPerLetter: Double = 4.0,
+        smartTimingMinimumWordLength: Int = 1,
         sentencePauseMultiplier: Double = 1.5,
         complexityTimingEnabled: Bool = false,
         complexityIntensity: Double = 0.5,
@@ -117,6 +125,7 @@ final class RSVPEngine {
         self.smartTimingEnabled = smartTimingEnabled
         self.sentencePauseEnabled = sentencePauseEnabled
         self.smartTimingPercentPerLetter = smartTimingPercentPerLetter
+        self.smartTimingMinimumWordLength = smartTimingMinimumWordLength
         self.sentencePauseMultiplier = sentencePauseMultiplier
         self.complexityTimingEnabled = complexityTimingEnabled
         self.complexityIntensity = complexityIntensity
@@ -232,7 +241,11 @@ final class RSVPEngine {
         var interval = baseInterval
 
         if smartTimingEnabled {
-            interval *= Self.smartTimingMultiplier(for: currentWord, percentPerLetter: smartTimingPercentPerLetter)
+            interval *= Self.smartTimingMultiplier(
+                for: currentWord,
+                percentPerLetter: smartTimingPercentPerLetter,
+                minimumWordLength: smartTimingMinimumWordLength
+            )
         }
 
         if sentencePauseEnabled && Self.endsWithSentencePunctuation(currentWord) {
@@ -259,14 +272,25 @@ final class RSVPEngine {
     }
 
     /// Returns a timing multiplier based on word length.
-    /// Each letter contributes `percentPerLetter`% to the interval increase.
-    /// E.g. at 4%, an 8-letter word yields a 1.32× multiplier.
-    /// Trailing punctuation (commas, etc.) adds a fixed 0.2 bonus when `percentPerLetter > 0`.
-    nonisolated static func smartTimingMultiplier(for word: String, percentPerLetter: Double = 4.0) -> Double {
+    /// Each letter contributes `percentPerLetter`% to the interval increase,
+    /// but only for words with at least `minimumWordLength` letters (after
+    /// trimming punctuation) — shorter words return 1.0 so they display at
+    /// exactly the base rate. E.g. at 4%, an 8-letter word yields 1.32×.
+    /// Trailing punctuation (commas, etc.) adds a fixed 0.2 bonus when
+    /// `percentPerLetter > 0` regardless of length — it marks a clause
+    /// boundary, not a long word.
+    nonisolated static func smartTimingMultiplier(
+        for word: String,
+        percentPerLetter: Double = 4.0,
+        minimumWordLength: Int = 1
+    ) -> Double {
         let trimmed = word.trimmingCharacters(in: .punctuationCharacters)
         let letterCount = trimmed.count
 
-        var multiplier = 1.0 + Double(letterCount) * (percentPerLetter / 100.0)
+        var multiplier = 1.0
+        if letterCount >= minimumWordLength {
+            multiplier += Double(letterCount) * (percentPerLetter / 100.0)
+        }
 
         if percentPerLetter > 0, hasTrailingPunctuation(word) {
             multiplier += 0.2

--- a/Strobe/Utilities/ReaderSettings.swift
+++ b/Strobe/Utilities/ReaderSettings.swift
@@ -15,6 +15,7 @@ enum ReaderSettings {
         nonisolated static let smartTimingEnabled = "smartTimingEnabled"
         nonisolated static let sentencePauseEnabled = "sentencePauseEnabled"
         nonisolated static let smartTimingPercentPerLetter = "smartTimingPercentPerLetter"
+        nonisolated static let smartTimingMinimumWordLength = "smartTimingMinimumWordLength"
         nonisolated static let sentencePauseMultiplier = "sentencePauseMultiplier"
         nonisolated static let complexityTimingEnabled = "complexityTimingEnabled"
         nonisolated static let complexityIntensity = "complexityIntensity"
@@ -33,6 +34,7 @@ enum ReaderSettings {
         nonisolated static let smartTimingEnabled = false
         nonisolated static let sentencePauseEnabled = false
         nonisolated static let smartTimingPercentPerLetter = 4.0
+        nonisolated static let smartTimingMinimumWordLength = 1
         nonisolated static let sentencePauseMultiplier = 1.5
         nonisolated static let complexityTimingEnabled = false
         nonisolated static let complexityIntensity = 0.5
@@ -51,6 +53,7 @@ enum ReaderSettings {
         let smartTimingEnabled: Bool
         let sentencePauseEnabled: Bool
         let smartTimingPercentPerLetter: Double
+        let smartTimingMinimumWordLength: Int
         let sentencePauseMultiplier: Double
         let complexityTimingEnabled: Bool
         let complexityIntensity: Double
@@ -65,6 +68,8 @@ enum ReaderSettings {
                 ?? Defaults.sentencePauseEnabled,
             smartTimingPercentPerLetter: defaults.object(forKey: Keys.smartTimingPercentPerLetter) as? Double
                 ?? Defaults.smartTimingPercentPerLetter,
+            smartTimingMinimumWordLength: defaults.object(forKey: Keys.smartTimingMinimumWordLength) as? Int
+                ?? Defaults.smartTimingMinimumWordLength,
             sentencePauseMultiplier: defaults.object(forKey: Keys.sentencePauseMultiplier) as? Double
                 ?? Defaults.sentencePauseMultiplier,
             complexityTimingEnabled: defaults.object(forKey: Keys.complexityTimingEnabled) as? Bool

--- a/Strobe/Views/ReaderView.swift
+++ b/Strobe/Views/ReaderView.swift
@@ -23,6 +23,7 @@ struct ReaderView: View {
     @AppStorage(ReaderSettings.Keys.smartTimingEnabled) private var smartTimingEnabled: Bool = ReaderSettings.Defaults.smartTimingEnabled
     @AppStorage(ReaderSettings.Keys.sentencePauseEnabled) private var sentencePauseEnabled: Bool = ReaderSettings.Defaults.sentencePauseEnabled
     @AppStorage(ReaderSettings.Keys.smartTimingPercentPerLetter) private var smartTimingPercentPerLetter: Double = ReaderSettings.Defaults.smartTimingPercentPerLetter
+    @AppStorage(ReaderSettings.Keys.smartTimingMinimumWordLength) private var smartTimingMinimumWordLength: Int = ReaderSettings.Defaults.smartTimingMinimumWordLength
     @AppStorage(ReaderSettings.Keys.sentencePauseMultiplier) private var sentencePauseMultiplierValue: Double = ReaderSettings.Defaults.sentencePauseMultiplier
     @AppStorage(ReaderSettings.Keys.complexityTimingEnabled) private var complexityTimingEnabled: Bool = ReaderSettings.Defaults.complexityTimingEnabled
     @AppStorage(ReaderSettings.Keys.complexityIntensity) private var complexityIntensity: Double = ReaderSettings.Defaults.complexityIntensity
@@ -68,6 +69,7 @@ struct ReaderView: View {
             smartTimingEnabled: timing.smartTimingEnabled,
             sentencePauseEnabled: timing.sentencePauseEnabled,
             smartTimingPercentPerLetter: timing.smartTimingPercentPerLetter,
+            smartTimingMinimumWordLength: timing.smartTimingMinimumWordLength,
             sentencePauseMultiplier: timing.sentencePauseMultiplier,
             complexityTimingEnabled: timing.complexityTimingEnabled,
             complexityIntensity: timing.complexityIntensity
@@ -224,6 +226,9 @@ struct ReaderView: View {
         }
         .onChange(of: smartTimingPercentPerLetter) { _, newValue in
             engine.smartTimingPercentPerLetter = newValue
+        }
+        .onChange(of: smartTimingMinimumWordLength) { _, newValue in
+            engine.smartTimingMinimumWordLength = newValue
         }
         .onChange(of: sentencePauseMultiplierValue) { _, newValue in
             engine.sentencePauseMultiplier = newValue

--- a/Strobe/Views/SettingsView.swift
+++ b/Strobe/Views/SettingsView.swift
@@ -7,6 +7,7 @@ struct SettingsView: View {
     @AppStorage(ReaderSettings.Keys.smartTimingEnabled) private var smartTimingEnabled: Bool = ReaderSettings.Defaults.smartTimingEnabled
     @AppStorage(ReaderSettings.Keys.sentencePauseEnabled) private var sentencePauseEnabled: Bool = ReaderSettings.Defaults.sentencePauseEnabled
     @AppStorage(ReaderSettings.Keys.smartTimingPercentPerLetter) private var smartTimingPercentPerLetter: Double = ReaderSettings.Defaults.smartTimingPercentPerLetter
+    @AppStorage(ReaderSettings.Keys.smartTimingMinimumWordLength) private var smartTimingMinimumWordLength: Int = ReaderSettings.Defaults.smartTimingMinimumWordLength
     @AppStorage(ReaderSettings.Keys.sentencePauseMultiplier) private var sentencePauseMultiplierValue: Double = ReaderSettings.Defaults.sentencePauseMultiplier
     @AppStorage(ReaderSettings.Keys.complexityTimingEnabled) private var complexityTimingEnabled: Bool = ReaderSettings.Defaults.complexityTimingEnabled
     @AppStorage(ReaderSettings.Keys.complexityIntensity) private var complexityIntensity: Double = ReaderSettings.Defaults.complexityIntensity
@@ -36,6 +37,20 @@ struct SettingsView: View {
             get: { textCleaningLevel == TextCleaningLevel.standard.rawValue },
             set: { textCleaningLevel = $0 ? TextCleaningLevel.standard.rawValue : TextCleaningLevel.none.rawValue }
         )
+    }
+
+    /// Bridges the Int-backed minimum word length setting to `Slider`'s Double binding.
+    private var smartTimingMinimumWordLengthSlider: Binding<Double> {
+        Binding(
+            get: { Double(smartTimingMinimumWordLength) },
+            set: { smartTimingMinimumWordLength = Int($0.rounded()) }
+        )
+    }
+
+    /// At the minimum (1) smart timing applies to every word — the label makes
+    /// that off-state legible instead of showing a cryptic "1+ letters".
+    private var minimumWordLengthLabel: String {
+        smartTimingMinimumWordLength <= 1 ? "All words" : "\(smartTimingMinimumWordLength)+ letters"
     }
 
     var body: some View {
@@ -186,6 +201,28 @@ struct SettingsView: View {
                                             .frame(minHeight: 44)
                                             .accessibilityLabel("Slowdown per letter")
                                             .accessibilityValue("\(Int(smartTimingPercentPerLetter)) percent")
+
+                                        HStack {
+                                            Text("Minimum word length")
+                                                .font(StrobeTheme.bodyFont(size: 14))
+                                                .foregroundStyle(StrobeTheme.textSecondary)
+                                            Spacer()
+                                            Text(minimumWordLengthLabel)
+                                                .font(StrobeTheme.bodyFont(size: 14, bold: true))
+                                                .foregroundStyle(StrobeTheme.textPrimary)
+                                        }
+                                        .padding(.top, 8)
+                                        Slider(value: smartTimingMinimumWordLengthSlider, in: 1...15, step: 1)
+                                            .tint(StrobeTheme.accent)
+                                            .frame(minHeight: 44)
+                                            .accessibilityLabel("Minimum word length")
+                                            .accessibilityValue(smartTimingMinimumWordLength <= 1
+                                                ? "All words"
+                                                : "\(smartTimingMinimumWordLength) or more letters")
+                                        Text("Shorter words show at your exact speed.")
+                                            .font(StrobeTheme.bodyFont(size: 11))
+                                            .foregroundStyle(StrobeTheme.textSecondary.opacity(0.7))
+                                            .frame(maxWidth: .infinity, alignment: .leading)
                                     }
                                     .padding(.leading, 4)
                                     .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))

--- a/StrobeTests/StrobeTests.swift
+++ b/StrobeTests/StrobeTests.swift
@@ -124,6 +124,48 @@ struct StrobeTests {
         #expect(punctuated > plain)
     }
 
+    @Test func smartTimingMultiplierSkipsWordsBelowMinimumLength() {
+        let multiplier = RSVPEngine.smartTimingMultiplier(for: "cat", minimumWordLength: 6)
+        #expect(multiplier == 1.0)
+    }
+
+    /// Once a word reaches the threshold, the full per-letter calculation
+    /// applies — the threshold gates the slowdown, it doesn't rescale it, so
+    /// existing per-letter tuning keeps producing the same long-word durations.
+    @Test func smartTimingMultiplierAppliesFullSlowdownAtMinimumLength() {
+        let exact = RSVPEngine.smartTimingMultiplier(for: "strobe", minimumWordLength: 6)
+        let long = RSVPEngine.smartTimingMultiplier(for: "characteristically", minimumWordLength: 6)
+        #expect(exact == RSVPEngine.smartTimingMultiplier(for: "strobe"))
+        #expect(long == RSVPEngine.smartTimingMultiplier(for: "characteristically"))
+        #expect(exact > 1.0)
+    }
+
+    /// Punctuation doesn't count toward the threshold, and the clause-boundary
+    /// bonus survives it — a short word with a trailing comma still gets its
+    /// brief pause even when the length slowdown is gated off.
+    @Test func smartTimingMultiplierKeepsPunctuationBonusBelowMinimumLength() {
+        let multiplier = RSVPEngine.smartTimingMultiplier(for: "and,", minimumWordLength: 6)
+        #expect(multiplier == 1.2)
+    }
+
+    /// The default threshold (1) must reproduce the historical behavior for
+    /// every token shape, including punctuation-only tokens like an em-dash
+    /// (0 letters, so it clears no threshold but keeps its 0.2 bonus).
+    @Test func smartTimingMinimumLengthOfOneMatchesLegacyBehavior() {
+        let expected: [(word: String, multiplier: Double)] = [
+            ("a", 1.04),                     // 1 letter
+            ("cat", 1.12),                   // 3 letters
+            ("and,", 1.32),                  // 3 letters + punctuation bonus
+            ("reading.", 1.48),              // 7 letters + punctuation bonus
+            ("—", 1.2),                      // 0 letters, punctuation bonus only
+            ("characteristically", 1.72),    // 18 letters
+        ]
+        for (word, multiplier) in expected {
+            let gated = RSVPEngine.smartTimingMultiplier(for: word, minimumWordLength: 1)
+            #expect(abs(gated - multiplier) < 0.0001, "mismatch for \(word)")
+        }
+    }
+
     // MARK: - Sentence pause
 
     @Test func sentencePauseDetectsFullStops() {
@@ -474,6 +516,7 @@ struct StrobeTests {
         #expect(snapshot.smartTimingEnabled == engine.smartTimingEnabled)
         #expect(snapshot.sentencePauseEnabled == engine.sentencePauseEnabled)
         #expect(snapshot.smartTimingPercentPerLetter == engine.smartTimingPercentPerLetter)
+        #expect(snapshot.smartTimingMinimumWordLength == engine.smartTimingMinimumWordLength)
         #expect(snapshot.sentencePauseMultiplier == engine.sentencePauseMultiplier)
         #expect(snapshot.complexityTimingEnabled == engine.complexityTimingEnabled)
         #expect(snapshot.complexityIntensity == engine.complexityIntensity)
@@ -486,11 +529,13 @@ struct StrobeTests {
 
         defaults.set(true, forKey: ReaderSettings.Keys.smartTimingEnabled)
         defaults.set(7.0, forKey: ReaderSettings.Keys.smartTimingPercentPerLetter)
+        defaults.set(6, forKey: ReaderSettings.Keys.smartTimingMinimumWordLength)
         defaults.set(2.5, forKey: ReaderSettings.Keys.sentencePauseMultiplier)
 
         let snapshot = ReaderSettings.timingSnapshot(from: defaults)
         #expect(snapshot.smartTimingEnabled == true)
         #expect(snapshot.smartTimingPercentPerLetter == 7.0)
+        #expect(snapshot.smartTimingMinimumWordLength == 6)
         #expect(snapshot.sentencePauseMultiplier == 2.5)
         // Unset keys still fall back to defaults.
         #expect(snapshot.complexityTimingEnabled == ReaderSettings.Defaults.complexityTimingEnabled)


### PR DESCRIPTION
Closes #7.

## Problem

Smart Timing applies its per-letter slowdown to **every** word, so the whole document runs below the WPM dial. Raising WPM to compensate also shrinks the long words' display time — the very thing the feature exists to protect (thanks @maplt for the well-articulated report).

## Solution

A **Minimum word length** slider under *Slowdown per letter* in Settings (visible when Smart Timing is on):

- Words **below** the threshold display at exactly the base WPM — the overall pace stays predictable.
- Words **at or above** it get the full existing per-letter calculation, so your current per-letter tuning keeps producing the same long-word durations (the threshold gates the slowdown, it doesn't rescale it).
- Range 1–15 letters, default **1 = "All words"**, which is bit-for-bit the historical behavior — no migration, no change for existing users.

### Design notes

- Letter count is measured after trimming punctuation, matching the existing multiplier semantics.
- The trailing-punctuation +0.2 bonus stays ungated: it marks a clause boundary, not a long word. This also keeps the default an exact no-op for punctuation-only tokens (em-dashes, ellipses).
- Setting live-updates an open reader mid-playback via the same `didSet → onPlaybackSettingChanged()` path as its sibling settings.

## Changes

- `RSVPEngine`: new `smartTimingMinimumWordLength` property + `minimumWordLength` parameter on `smartTimingMultiplier(for:percentPerLetter:minimumWordLength:)` (defaulted, so existing call sites are untouched)
- `ReaderSettings`: key, default, `TimingSnapshot` field and read — single source of truth preserved
- `ReaderView`: engine seeding + `.onChange` live update
- `SettingsView`: slider row styled identically to *Slowdown per letter*, with "All words" shown at 1 and "N+ letters" otherwise; accessibility label/value included
- `CLAUDE.md`: settings-key list updated (also added `holdSpeedAdjustEnabled`, which was missing from the list)

## Tests

New Swift Testing cases pin the behavior:

- below-threshold word → exactly 1.0×
- at/above threshold → identical to the ungated calculation (boundary inclusive)
- short punctuated word below threshold keeps the clause-boundary bonus
- threshold 1 reproduces the historical multipliers across token shapes (`a`, `cat`, `and,`, `reading.`, `—`, `characteristically`)
- both `TimingSnapshot` tests extended with the new field (defaults-match-engine + stored-value read)

🤖 Generated with [Claude Code](https://claude.com/claude-code)